### PR TITLE
Haskell for non root

### DIFF
--- a/src/haskell/install.sh
+++ b/src/haskell/install.sh
@@ -44,7 +44,15 @@ if [[ "${INSTALL_STACK_GHCUP_HOOK}" = "false" ]]; then
     export BOOTSTRAP_HASKELL_INSTALL_NO_STACK_HOOK="true"
 fi
 
+# The installation script is designed to be run by the non-root user
+# The files need to be in the remote user's ~/ home directory
+ROOT_HOME="${HOME}"
+export HOME="${_REMOTE_USER_HOME}"
+
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | $SHELL
+
+export HOME="${ROOT_HOME}"
+chown -R "${_REMOTE_USER}:${_REMOTE_USER}" "${_REMOTE_USER_HOME}"
 
 # without restarting the shell, ghci location would not be resolved from the updated PATH
 exec $SHELL

--- a/src/haskell/install.sh
+++ b/src/haskell/install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 GHC_VERSION="${GHCVERSION:-"latest"}"
-CABAL_VERSION="${CABALVERSION:-"latest"}" 
-INCLUDE_STACK="${INSTALLSTACK:-"true"}" 
-ADJUST_BASHRC="${ADJUSTBASH:-"true"}" 
+CABAL_VERSION="${CABALVERSION:-"latest"}"
+INCLUDE_STACK="${INSTALLSTACK:-"true"}"
+ADJUST_BASHRC="${ADJUSTBASH:-"true"}"
 
 INSTALL_STACK_GHCUP_HOOK="${INSTALLSTACKGHCUPHOOK:-"true"}"
 
-# Clean up 
+# Clean up
 rm -rf /var/lib/apt/lists/*
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -17,7 +17,7 @@ fi
 
 # Checks if packages are installed and installs them if not
 check_packages() {
-    if ! dpkg -s "$@" > /dev/null 2>&1; then
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
         if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
             echo "Running apt-get update..."
             apt-get update -y
@@ -30,27 +30,26 @@ check_packages curl build-essential libffi-dev libffi8ubuntu1 libgmp-dev libgmp1
 
 export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
 export GHCUP_USE_XDG_DIRS=1
-export BOOTSTRAP_HASKELL_GHC_VERSION="${GHC_VERSION}" 
+export BOOTSTRAP_HASKELL_GHC_VERSION="${GHC_VERSION}"
 export BOOTSTRAP_HASKELL_CABAL_VERSION="${CABAL_VERSION}"
 export BOOTSTRAP_HASKELL_DOWNLOADER="curl"
 
-if [[ "${INCLUDE_STACK}" = "false" ]] ; then
+if [[ "${INCLUDE_STACK}" = "false" ]]; then
     export BOOTSTRAP_HASKELL_INSTALL_NO_STACK="true"
 fi
-if [[ "${ADJUST_BASH}" = "true" ]] ; then
+if [[ "${ADJUST_BASH}" = "true" ]]; then
     export BOOTSTRAP_HASKELL_ADJUST_BASHRC="true"
 fi
-if [[ "${INSTALL_STACK_GHCUP_HOOK}" = "false" ]] ; then
+if [[ "${INSTALL_STACK_GHCUP_HOOK}" = "false" ]]; then
     export BOOTSTRAP_HASKELL_INSTALL_NO_STACK_HOOK="true"
 fi
 
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | $SHELL
 
-
 # without restarting the shell, ghci location would not be resolved from the updated PATH
 exec $SHELL
 
-# Clean up 
+# Clean up
 rm -rf /var/lib/apt/lists/*
 
 echo "Done!"


### PR DESCRIPTION
## Fix

- Temporarily change `HOME` to `_REMOTE_USER_HOME` for the execution of the install script.
- Recursively `chown` back to the `_REMOTE_USER`.

I've also auto-formatted the file, but separated that into a different commit in case you don't want those changes.

## Preexisting Behavior

The [Haskell feature](https://github.com/devcontainers-contrib/features/tree/main/src/haskell) runs the install such that Cabal, Stack, etc. are installed in `/root` and are not useful when running the dev container in VS Code (or presumably other use cases).

The [GHCup install instructions](https://www.haskell.org/ghcup/install/) mention that the commands should be run as non-root:
> These commands should be run as **non-root/non-admin user**.

### Reproduction

The following `.devcontainer.json` illustrates the issue (and is what VS Code creates when selecting default values for an Ubuntu devcontainer with the Haskell feature added):

```
{
	"name": "Ubuntu",
	"image": "mcr.microsoft.com/devcontainers/base:jammy",
	"features": {
		"ghcr.io/devcontainers-contrib/features/haskell:1": {}
	}
}
```

After building and opening VS Code in the devcontainer, a new terminal produces the following:
```
vscode ➜ /workspaces/haskell_example $ ghcup --version
bash: ghcup: command not found
vscode ➜ /workspaces/haskell_example $ cabal --version
bash: cabal: command not found
vscode ➜ /workspaces/haskell_example $ stack --version
bash: stack: command not found
vscode ➜ /workspaces/haskell_example $ ls -AF ~/
.bash_logout  .bashrc  .config/  .gitconfig  .gnupg/  .oh-my-zsh/  .profile  .ssh/  .vscode-server/  .zshrc
vscode ➜ /workspaces/haskell_example $ sudo ls -AF /root
.bashrc  .cabal/  .cache/  .config/  .local/  .oh-my-zsh/  .profile  .stack/  .zshrc
```

Note the existence of `.cabal` and `.stack` in `/root`.

In the preexisting condition, you can verify that installing as the user succeeds by executing the following:
```
curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=latest BOOTSTRAP_HASKELL_CABAL_VERSION=latest BOOTSTRAP_HASKELL_INSTALL_STACK=1 BOOTSTRAP_HASKELL_INSTALL_HLS=1 BOOTSTRAP_HASKELL_ADJUST_BASHRC=P $SHELL
```

After everything is downloaded and installed, you'll have to source `~/.bashrc` and then you can see the success:
```
vscode ➜ /workspaces/haskell_example $ ghcup --version
bash: ghcup: command not found
vscode ➜ /workspaces/haskell_example $ source ~/.bashrc 
vscode ➜ /workspaces/haskell_example $ ghcup --version
The GHCup Haskell installer, version v0.1.18.0
vscode ➜ /workspaces/haskell_example $ cabal --version
cabal-install version 3.8.1.0
compiled using version 3.8.1.0 of the Cabal library 
vscode ➜ /workspaces/haskell_example $ stack --version
Version 2.9.1, Git revision 409d56031b4240221d656db09b2ba476fe6bb5b1 x86_64 hpack-0.35.0
vscode ➜ /workspaces/haskell_example $ ls -AF ~/
.bash_logout  .bashrc  .cabal/  .config/  .ghcup/  .gitconfig  .gnupg/  .oh-my-zsh/  .profile  .ssh/  .stack/  .vscode-server/  .zshrc
```