### PR TITLE
Fix pulumi root/non-root user installation

### DIFF
--- a/src/pulumi/devcontainer-feature.json
+++ b/src/pulumi/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Pulumi",
     "id": "pulumi",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "Pulumi is a modern infrastructure as code platform",
     "documentationURL": "https://github.com/devcontainers-contrib/features/tree/main/src/pulumi",
     "options": {

--- a/src/pulumi/install.sh
+++ b/src/pulumi/install.sh
@@ -5,7 +5,7 @@ BASH_COMPLETION="${BASHCOMPLETION:-"true"}"
 
 set -e
 
-# Clean up 
+# Clean up
 rm -rf /var/lib/apt/lists/*
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -27,35 +27,41 @@ check_packages() {
 # making sure curl is there, you never know
 check_packages curl
 
-# making sure shell configs are there, as pulumi installation script rely on 
-# their existance in order to add its binary to the user's PATH
-if [ ! -f "${HOME}/.bashrc" ] || [ ! -s "${HOME}/.bashrc" ] ; then
-    cp  /etc/skel/.bashrc "${HOME}/.bashrc"
-fi
-if  [ ! -f "${HOME}/.profile" ] || [ ! -s "${HOME}/.profile" ] ; then
-    cp  /etc/skel/.profile "${HOME}/.profile"
-fi
+# We run as the non-root user so to fix https://github.com/devcontainers-contrib/features/issues/80
+# Note that we substitute SOME variables before evaluation, and some are
+# substituted inside the $_REMOTE_USER shell. Particularily $HOME which needs to
+# be from the $_REMOTE_USER, and $VERSION which needs to come from this script.
+sudo -iu "$_REMOTE_USER" <<EOF
+    # making sure shell configs are there, as pulumi installation script rely on
+    # their existance in order to add its binary to the user's PATH
+    if [ ! -f "\${HOME}/.bashrc" ] || [ ! -s "\${HOME}/.bashrc" ] ; then
+        cp  /etc/skel/.bashrc "\${HOME}/.bashrc"
+    fi
+    if  [ ! -f "\${HOME}/.profile" ] || [ ! -s "\${HOME}/.profile" ] ; then
+        cp  /etc/skel/.profile "\${HOME}/.profile"
+    fi
 
-# using "... | $SHELL" instead of the documented "... | sh" in order to support .bashrc/.zshrc as 
-# pulumi installation script will rely on $SHELL variable (and has no support for SHELL=sh yet)
-if [ "${VERSION}" == "latest" ]; then
-	curl -fsSL https://get.pulumi.com | $SHELL
-else
-	curl -fsSL https://get.pulumi.com | $SHELL -s -- --version $VERSION
-fi
+    # using "... | $SHELL" instead of the documented "... | sh" in order to support .bashrc/.zshrc as
+    # pulumi installation script will rely on $SHELL variable (and has no support for SHELL=sh yet)
+    if [ "${VERSION}" == "latest" ]; then
+        curl -fsSL https://get.pulumi.com | $SHELL
+    else
+        curl -fsSL https://get.pulumi.com | $SHELL -s -- --version $VERSION
+    fi
 
-# if pulumi script failed to insert to path, fallback to soft linking it in /usr/local/bin 
-exec $SHELL
-if ! [ -x "$(command -v pulumi)" ]; then
-    ln -s $HOME/.pulumi/bin/pulumi /usr/local/bin/pulumi
-fi
+    # if pulumi script failed to insert to path, fallback to soft linking it in /usr/local/bin
+    exec $SHELL
+    if ! [ -x "$(command -v pulumi)" ]; then
+        ln -s \$HOME/.pulumi/bin/pulumi /usr/local/bin/pulumi
+    fi
 
-# finally we are adding bash completion. zsh support will be added soon
-if [[ "${BASH_COMPLETION}" = "true" ]] ; then
-    pulumi gen-completion bash > /etc/bash_completion.d/pulumi
-fi
+    # finally we are adding bash completion. zsh support will be added soon
+    if [[ "${BASH_COMPLETION}" = "true" ]] ; then
+        pulumi gen-completion bash > /etc/bash_completion.d/pulumi
+    fi
+EOF
 
-# Clean up 
+# Clean up
 rm -rf /var/lib/apt/lists/*
 
 echo "Done!"


### PR DESCRIPTION
**Unsure if the tests pass and if this actually works yet, hence DRAFT**

This will basically wrap the install script in a big `sudo -iu $_REMOTE_USER` block so that it gets executed as the right user.

```sh
# We run as the non-root user so to fix https://github.com/devcontainers-contrib/features/issues/80
# Note that we substitute SOME variables before evaluation, and some are
# substituted inside the $_REMOTE_USER shell. Particularily $HOME which needs to
# be from the $_REMOTE_USER, and $VERSION which needs to come from this script.
sudo -iu "$_REMOTE_USER" <<EOF
 ...
```

See https://github.com/devcontainers-contrib/features/commit/e3b9039bd2722c40ffa1f848822086c971cf643b

It also bumps the version from 1.0.2 to 1.1.0? Should it bump even farther (i.e. to 2.0.0) since it is a "breaking" change? Is it even a breaking change?