### PR TITLE
Fix typo in typescript

### DIFF
--- a/src/typescript/install.sh
+++ b/src/typescript/install.sh
@@ -37,7 +37,7 @@ check_packages() {
  
 # install node+npm if does not exists
 if ! type npm > /dev/null 2>&1; then
-    echo "Installing npde and npm..."
+    echo "Installing node and npm..."
     check_packages curl
     curl -fsSL https://raw.githubusercontent.com/devcontainers/features/main/src/node/install.sh | $SHELL
     export NVM_DIR=/usr/local/share/nvm


### PR DESCRIPTION
There is a typo that printing `node` as `npde`, this PR fixed it.