### PR TITLE
Use suggestions from @fred-asimov

### DIFF
--- a/src/pulumi/devcontainer-feature.json
+++ b/src/pulumi/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Pulumi",
     "id": "pulumi",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Pulumi is a modern infrastructure as code platform",
     "documentationURL": "https://github.com/devcontainers-contrib/features/tree/main/src/pulumi",
     "options": {

--- a/src/pulumi/install.sh
+++ b/src/pulumi/install.sh
@@ -59,7 +59,7 @@ sudo -iu "$_REMOTE_USER" <<EOF
     # finally we are adding bash completion. zsh support will be added soon
     if [[ "${BASH_COMPLETION}" = "true" ]] ; then
         # We need sudo here since we are running under \$_REMOTE_USER
-        sudo pulumi gen-completion bash > /etc/bash_completion.d/pulumi
+        pulumi gen-completion bash | sudo tee /etc/bash_completion.d/pulumi
     fi
 EOF
 

--- a/src/pulumi/install.sh
+++ b/src/pulumi/install.sh
@@ -59,7 +59,7 @@ sudo -iu "$_REMOTE_USER" <<EOF
     # finally we are adding bash completion. zsh support will be added soon
     if [[ "${BASH_COMPLETION}" = "true" ]] ; then
         # We need sudo here since we are running under \$_REMOTE_USER
-        pulumi gen-completion bash | sudo tee /etc/bash_completion.d/pulumi
+        pulumi gen-completion bash | sudo tee /etc/bash_completion.d/pulumi > /dev/null
     fi
 EOF
 


### PR DESCRIPTION
This is the same as #140, but I made an oopsie and renamed the branch, which closed the #140 PR. My bad!

This PR...
- Adds `pulumi gen-completion bash | sudo tee /etc/bash_completion.d/pulumi > /dev/null`

And hey look! I remembered to bump the version (after being prodded by @fred-asimov to do so, but still 🙂)