### PR TITLE
Update the version like I should have done in #139 🙄

### DIFF
--- a/src/haskell/devcontainer-feature.json
+++ b/src/haskell/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Haskell",
     "id": "haskell",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Installs Haskell. An advanced, purely functional programming language",
     "documentationURL": "https://github.com/devcontainers-contrib/features/tree/main/src/haskell",
     "options": {


### PR DESCRIPTION
This PR:
- Changes the Haskell feature version from 2.0.0 to 2.0.1

Hopefully that will trigger a release to make the changes in #139 apply!