### PR TITLE
Bump version for sudo fix

### DIFF
--- a/src/haskell/devcontainer-feature.json
+++ b/src/haskell/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Haskell",
     "id": "haskell",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Installs Haskell. An advanced, purely functional programming language",
     "documentationURL": "https://github.com/devcontainers-contrib/features/tree/main/src/haskell",
     "options": {


### PR DESCRIPTION
I believe we need this version bump for the https://github.com/devcontainers-contrib/features/pull/139#event-7920244904 fix to go out to anyone who has already pulled v2 before this PR.