### PR TITLE
Add support notice about debian-based only

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Just add a `.devcontainer/devcontainer.json` file with a `features` key. It's
 very similar to NPM's `package.json` and `dependencies` object, just with the
 addition of an `options` object.
 
-📚 Make sure to inspect each feature for feature-specific options
+📚 Make sure to inspect each feature for feature-specific options \
+⚠️ We only officially support [debian](https://hub.docker.com/_/debian)-based images
 
 ```json
 {


### PR DESCRIPTION
The official devcontainers/features only support debian-based images, so we should probably follow suit.  This also clears up any confusion about our lowest-common-denominator that we need to prepare/test for.

![image](https://user-images.githubusercontent.com/61068799/205223625-4340b118-08a3-4464-9854-789690be44c8.png)

https://github.com/devcontainers/features#:~:text=Any%20generic%2C%20debian%2Dbased%20image.