### PR TITLE
Add the option to install packages like the hlint linter

### DIFF
--- a/src/haskell/devcontainer-feature.json
+++ b/src/haskell/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Haskell",
     "id": "haskell",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "description": "Installs Haskell. An advanced, purely functional programming language",
     "documentationURL": "https://github.com/devcontainers-contrib/features/tree/main/src/haskell",
     "options": {
@@ -25,6 +25,16 @@
             ],
             "default": "recommended",
             "description": "Select the Cabal (a system for building and packaging Haskell libraries and programs) version to install."
+        },
+        "globalPackages": {
+            "type": "string",
+            "proposals": [
+                "",
+                "hlint",
+                "hlint hspec pandoc"
+            ],
+            "default": "",
+            "description": "Packages to install via `cabal install`, such as `hlint` for linting. Separate with spaces. This will add significant initial build time."
         },
         "installHLS": {
             "type": "boolean",

--- a/src/haskell/install.sh
+++ b/src/haskell/install.sh
@@ -7,6 +7,7 @@ INCLUDE_HLS="${INSTALLHLS:-"true"}"
 ADJUST_BASHRC="${ADJUSTBASH:-"true"}"
 
 INSTALL_STACK_GHCUP_HOOK="${INSTALLSTACKGHCUPHOOK:-"true"}"
+CABAL_INSTALLS=`echo "${GLOBALPACKAGES:-""}" | tr ',' ' '`
 
 # Clean up
 rm -rf /var/lib/apt/lists/*
@@ -59,6 +60,13 @@ sudo -iu "$_REMOTE_USER" <<EOF
 
 	# Install instructions from https://www.haskell.org/ghcup/#
 	curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+
+	# Update PATH so that Cabal is accessible, the same as will be done via ~/.bashrc in the future
+	. "${_REMOTE_USER_HOME}/.local/share/ghcup/env"
+
+	if [[ ! -z "${CABAL_INSTALLS}" ]]; then
+		cabal update && echo "${CABAL_INSTALLS}" | xargs cabal install
+	fi
 EOF
 
 # without restarting the shell, ghci location would not be resolved from the updated PATH


### PR DESCRIPTION
I'd like to add another option which I'll do in a separate PR, but with this change the Haskell feature can install an arbitrary list of packages through Haskell to support various VS Code Extensions (see https://github.com/devcontainers-contrib/features/issues/135).

I'm defaulting to no packages, since it adds so much to the build time, but `hlint` is necessary for the linting extension I've mentioned in https://github.com/devcontainers-contrib/features/issues/135.