### PR TITLE
Fold Gitter into updated quicknav in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Community devcontainer features
 
-[![Gitter](https://img.shields.io/gitter/room/devcontainers-contrib/community)](https://gitter.im/devcontainers-contrib/community)
-
 🐳 Extra add-in features for
 [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers) and
 [GitHub Codespaces](https://github.com/features/codespaces)
@@ -10,10 +8,11 @@
 
 ![](https://i.imgur.com/W7t3YsC.png)
 
-**[Overview](https://github.com/devcontainers-contrib/features#readme)** |
-[User docs](https://github.com/devcontainers-contrib/features#usage) |
-[Contributing](https://github.com/devcontainers-contrib/features/blob/main/CONTRIBUTING.md)
-| [Developer wiki](https://github.com/devcontainers-contrib/features/wiki)
+[![Overview](https://img.shields.io/static/v1?style=for-the-badge&message=Overview&color=018EF5&logo=ReadMe&logoColor=FFFFFF&label=)](https://github.com/devcontainers-contrib/features#readme)
+[![User docs](https://img.shields.io/static/v1?style=for-the-badge&message=User%20docs&color=018EF5&logo=ReadMe&logoColor=FFFFFF&label=)](https://github.com/devcontainers-contrib/features#usage)
+[![Contribute](https://img.shields.io/static/v1?style=for-the-badge&message=Contribute&color=181717&logo=GitHub&logoColor=FFFFFF&label=)](https://github.com/devcontainers-contrib/features/blob/main/CONTRIBUTING.md)
+[![Dev wiki](https://img.shields.io/static/v1?style=for-the-badge&message=Dev%20wiki&color=181717&logo=GitHub&logoColor=FFFFFF&label=)](https://github.com/devcontainers-contrib/features/wiki)
+[![Chat](https://img.shields.io/static/v1?style=for-the-badge&message=Chat&color=ED1965&logo=Gitter&logoColor=FFFFFF&label=)](https://gitter.im/devcontainers-contrib/community)
 
 </div>
 

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,8 +1,9 @@
 <div align="center">
 
-[Overview](https://github.com/devcontainers-contrib/features#readme) |
-[User docs](https://github.com/devcontainers-contrib/features#usage) |
-[Contributing](https://github.com/devcontainers-contrib/features/blob/main/CONTRIBUTING.md)
-| **[Developer wiki](https://github.com/devcontainers-contrib/features/wiki)**
+[![Overview](https://img.shields.io/static/v1?style=for-the-badge&message=Overview&color=018EF5&logo=ReadMe&logoColor=FFFFFF&label=)](https://github.com/devcontainers-contrib/features#readme)
+[![User docs](https://img.shields.io/static/v1?style=for-the-badge&message=User%20docs&color=018EF5&logo=ReadMe&logoColor=FFFFFF&label=)](https://github.com/devcontainers-contrib/features#usage)
+[![Contribute](https://img.shields.io/static/v1?style=for-the-badge&message=Contribute&color=181717&logo=GitHub&logoColor=FFFFFF&label=)](https://github.com/devcontainers-contrib/features/blob/main/CONTRIBUTING.md)
+[![Dev wiki](https://img.shields.io/static/v1?style=for-the-badge&message=Dev%20wiki&color=181717&logo=GitHub&logoColor=FFFFFF&label=)](https://github.com/devcontainers-contrib/features/wiki)
+[![Chat](https://img.shields.io/static/v1?style=for-the-badge&message=Chat&color=ED1965&logo=Gitter&logoColor=FFFFFF&label=)](https://gitter.im/devcontainers-contrib/community)
 
 </div>


### PR DESCRIPTION
Discussion on Gitter about preference of quicknav location in flow of document:

<details>
  <summary>December 6, 2022 4:59 PM <a href="https://gitter.im/devcontainers-contrib/community?at=638fc94d8bdea01368a392bf">(link)</a></summary>

> ![](https://files.gitter.im/638e2cb86da0373984a03f97/BPt5/image.png) ![](https://files.gitter.im/638e2cb86da0373984a03f97/gmBo/image.png) ![](https://files.gitter.im/638e2cb86da0373984a03f97/lqEW/image.png) ![](https://files.gitter.im/638e2cb86da0373984a03f97/XOYE/image.png)

</details>