### PR TITLE
Provide a method to ensure HLS will work

### DIFF
--- a/src/haskell/devcontainer-feature.json
+++ b/src/haskell/devcontainer-feature.json
@@ -41,6 +41,11 @@
             "default": true,
             "description": "Install HLS, the Haskell Language Server."
         },
+        "downgradeGhcToSupportHls": {
+            "type": "boolean",
+            "default": true,
+            "description": "This will downgrade GHC to the closest version supported by HLS. There is often a gap between a GHC release and tooling support."
+        },
         "installStack": {
             "type": "boolean",
             "default": true,


### PR DESCRIPTION
While the GHC could be pinned, this provides a way to ensure you have the latest, supported GHC version so that the Haskell Language Server can be programmatically guaranteed to work in a fresh devcontainer config.

I believe that this will fully resolve https://github.com/devcontainers-contrib/features/issues/135