### PR TITLE
Bump Haskell version for GHC downgrade feature

### DIFF
--- a/src/haskell/devcontainer-feature.json
+++ b/src/haskell/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Haskell (via ghcup)",
     "id": "haskell",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Installs Haskell. An advanced, purely functional programming language",
     "documentationURL": "https://github.com/devcontainers-contrib/features/tree/main/src/haskell",
     "options": {


### PR DESCRIPTION
Sorry! I should've remembered to do this in https://github.com/devcontainers-contrib/features/pull/183.