### PR TITLE
feat(zsh-plugins): add feature that installs zsh plugins

### DIFF
--- a/src/zsh-plugins/devcontainer-feature.json
+++ b/src/zsh-plugins/devcontainer-feature.json
@@ -1,0 +1,31 @@
+{
+  "name": "ZSH Plugins",
+  "id": "zsh-plugins",
+  "version": "0.0.1",
+  "description": "Install (Oh-My-)ZSH plugins",
+  "documentationURL": "http://github.com/devcontainers-contrib/features/tree/main/src/zsh-plugins",
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils",
+    "ghcr.io/devcontainers/features/git"
+  ],
+  "options": {
+    "plugins": {
+      "type": "string",
+      "default": "",
+      "proposals": ["ssh-agent npm"],
+      "description": "Space separated list of ZSH plugin names that will be added to .zshrc"
+    },
+    "omzPlugins": {
+      "type": "string",
+      "default": "",
+      "proposals": ["https://github.com/zsh-users/zsh-autosuggestions"],
+      "description": "Space separated list of Oh-My-ZSH custom plugin Git URLs that will be cloned"
+    },
+    "username": {
+      "type": "string",
+      "default": "",
+      "proposals": ["root", "node", "vscode"],
+      "description": "For which user to setup ZSH plugins, by default uses 'remoteUser' or 'containerUser' from config"
+    }
+  }
+}

--- a/src/zsh-plugins/install.sh
+++ b/src/zsh-plugins/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+PLUGINS=${PLUGINS:-""}
+OMZSH_PLUGINS=${OMZPLUGINS:-""}
+USERNAME=${USERNAME:-$_REMOTE_USER}
+
+if [ "$USERNAME" = "root" ]; then
+  USER_LOCATION="/root"
+else
+  USER_LOCATION="/home/$USERNAME"
+fi
+
+ZSH_CONFIG="$USER_LOCATION/.zshrc"
+OMZSH_PLUGINS_LOCATION="$USER_LOCATION/.oh-my-zsh/custom/plugins"
+
+# Install custom oh-my-zsh plugins from OMZSH_PLUGINS
+currdir=$(pwd)
+mkdir -p "$OMZSH_PLUGINS_LOCATION"
+cd "$OMZSH_PLUGINS_LOCATION" || exit
+
+plugins=( "${OMZSH_PLUGINS}" )
+
+for plugin in "${plugins[@]}"
+do
+  git clone $plugin
+done
+
+cd "$currdir" || exit
+
+# Activate zsh plugins from PLUGINS
+sed -i -e "s/plugins=.*/plugins=(git ${PLUGINS})/g" "$ZSH_CONFIG"

--- a/test/zsh-plugins/install_plugins.sh
+++ b/test/zsh-plugins/install_plugins.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+# Test ZSH npm plugin
+check "npm plugin active" zsh -i -c "echo \$plugins" | grep "npm"
+check "npm aliases available" zsh -i -c "which npmR" | grep "npm run"
+
+# Test Oh-My-ZSH dogesay plugin
+check "dogesay plugin active" zsh -i -c "echo \$plugins" | grep "dogesay"
+check "dogesay custom plugin exists" zsh -i -c "ls ~/.oh-my-zsh/custom/plugins/dogesay"
+
+reportResults

--- a/test/zsh-plugins/scenarios.json
+++ b/test/zsh-plugins/scenarios.json
@@ -1,0 +1,11 @@
+{
+  "install_plugins": {
+    "image": "mcr.microsoft.com/devcontainers/base:debian",
+    "features": {
+      "zsh-plugins": {
+        "plugins": "npm dogesay",
+        "omzPlugins": "https://github.com/txstc55/dogesay"
+      }
+    }
+  }
+}

--- a/test/zsh-plugins/test.sh
+++ b/test/zsh-plugins/test.sh
@@ -4,7 +4,6 @@ set -e
 
 source dev-container-features-test-lib
 
-# TODO: Configure some zsh plugins and check them here
 check "zsh --version" zsh --version
 
 reportResults

--- a/test/zsh-plugins/test.sh
+++ b/test/zsh-plugins/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+# TODO: Configure some zsh plugins and check them here
+check "zsh --version" zsh --version
+
+reportResults


### PR DESCRIPTION
Hi, I would like to contribute a feature that I've recently built for my own dev container setup that allows to install (Oh-My-)ZSH plugins from configuration.

Here's the example of how it's intended to be used:
```jsonc
{
  "features": {
    "ghcr.io/devcontainers/features/common-utils:1": {},
    "./zsh-plugins": {
      "plugins": "npm zsh-autosuggestions", // <-- zsh plugins go here
      "omzPlugins": "https://github.com/zsh-users/zsh-autosuggestions" // <-- oh-my-zsh plugin git urls go here
    }
  }
}
```

I was trying to follow your contributing guide but it seems outdated as it says to run script from `scripts/` folder to generate a feature but there is no such folder anymore.
So I basically created a feature manually and added a test file which for now does not really test the plugin and I need help with it.
Basically I need a way to configure a feature inside a test to set some zsh plugins to be able to assert that they were installed.
Could you please help me how this may be achieved?

Off-topic: I have 2 more generic features that I would like to contribute: one for persisting bash/zsh history in volume so that container rebuilds won't loose commands history and the second feature for persisting vscode extensions folder to allow for faster startup times after container is rebuilt, so would it be fine to contribute them here as well?

Thanks!
