### PR TITLE
add support to zig to install dev builds of zig

### DIFF
--- a/src/zig/devcontainer-feature.json
+++ b/src/zig/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Zig (via ziglang.org)",
     "id": "zig",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "Zig is a general-purpose programming language and toolchain for maintaining robust, optimal and reusable software.",
     "documentationURL": "https://github.com/devcontainers-contrib/features/tree/main/src/zig",
     "options": {


### PR DESCRIPTION
As Zig is still a young language a large number of projects and libraries target the latest development version.

This patch makes it possible to install the latest development version.