### PR TITLE
Fix package spec by using at symbol.

### DIFF
--- a/src/npm-package/install.sh
+++ b/src/npm-package/install.sh
@@ -53,7 +53,7 @@ install_via_npm() {
 	if [ "$VERSION" = "latest" ]; then
 		npm_installation="$PACKAGE"
 	else
-		npm_installation="$PACKAGE==$VERSION"
+		npm_installation="${PACKAGE}@${VERSION}"
 	fi
 
 	npm install -g --omit=dev "$npm_installation"


### PR DESCRIPTION
Tried to use the feature `npm-package:1` but opening in container failed with:

```
Options       :
    PACKAGE="wrangler"
    VERSION="2.6.2"
===========================================================================
[2022-12-23T10:56:57.516Z] npm
[2022-12-23T10:56:57.516Z]  ERR! code EINVALIDTAGNAME
[2022-12-23T10:56:57.519Z] npm ERR! Invalid tag name "wrangler==2.6.2" of package "wrangler==2.6.2": Tags may not have any characters that encodeURIComponent encodes.
[2022-12-23T10:56:57.521Z] 
npm ERR!
```

I could be doing something wrong but it seems npm install `package-spec` doesn't support the format `PACKAGE==VERSION`.
Quoting https://docs.npmjs.com/cli/v9/commands/npm-install#description 

> A package is:

    a) a folder containing a program described by a [package.json](https://docs.npmjs.com/cli/v9/configuring-npm/package-json) file
    b) a gzipped tarball containing (a)
    c) a url that resolves to (b)
    d) a <name>@<version> that is published on the [registry](https://docs.npmjs.com/cli/v9/using-npm/registry) (see registry) with (c)
    e) a <name>@<tag> (see [npm dist-tag](https://docs.npmjs.com/cli/v9/commands/npm-dist-tag)) that points to (d)
    f) a <name> that has a "latest" tag satisfying (e)
    g) a <git remote url> that resolves to (a)
    
My proposal complies with bullet **d)**

Cheers