### PR TITLE
Improve README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,38 @@
-<div align="center">
-
-[Overview](https://github.com/devcontainers-contrib/features#readme)
-| [User docs](https://github.com/devcontainers-contrib/features#usage)
-| **[Contributing](https://github.com/devcontainers-contrib/features/blob/main/CONTRIBUTING.md)**
-| [Developer wiki](https://github.com/devcontainers-contrib/features/wiki)
-
-</div>
-
 **First off, thanks for taking the time to contribute! ❤️**
 
-All types of contributions are encouraged and valued, no matter if it's a bug report 🐛, a feature request 💡, or a Pull Request 🚀.
+All types of contributions are encouraged and valued, no matter if it's a bug
+report 🐛, a feature request 💡, or a Pull Request 🚀.
 
-- ❓ [I have a question](https://github.com/devcontainers-contrib/features/discussions/new?category=q-a)
-- 🐛 [I want to submit a bug report](https://github.com/devcontainers-contrib/features/issues/new)
-- 💡 [I want to suggest a feature](https://github.com/devcontainers-contrib/features/issues/new)
-- 🚀 [I want to contribute](https://github.com/devcontainers-contrib/features/wiki)
+<!-- prettier-ignore-start -->
+- **❓ I have a question:** [Open a Discussion](https://github.com/devcontainers-contrib/features/discussions/new?category=q-a)
+- **🐛 I found a bug:** [Open an Issue](https://github.com/devcontainers-contrib/features/issues/new)
+- **💡 I want to request a new feature:** [Open an Issue](https://github.com/devcontainers-contrib/features/issues/new)
+- **💻 I want to add a new feature:** [See below](#adding-a-feature)
+<!-- prettier-ignore-end -->
 
-If you like the project, but just don't have time to contribute, that's OK too! You can also star the project ⭐, tweet about it 💬, or backlink to our repository 🔗.
+If you like the project, but just don't have time to contribute, that's OK too!
+You can also star the project ⭐, rave about it online 💬, or add a link to us
+🔗 in your project's readme.
 
 ⚠️ You must never report security 🔒 related issues, vulnerabilities or bugs
 including sensitive information to the issue tracker, or elsewhere in public.
-Instead sensitive bugs must be sent by email to <devcontainers.contrib+features.security@gmail.com>.
+Instead sensitive bugs must be sent by email to
+devcontainers.contrib+features.security@gmail.com.
 
-👩‍⚖️ When contributing to this project, you must agree that you have authored 100%
-of the content, that you have the necessary rights to the content and that the
-content you contribute may be provided under the project license.
+## Adding a feature
+
+1. 🔀 Fork the repo
+2. 💻 Open the repo in your editor
+3. 👨‍💻 Follow the [How to add a feature] guide on the dev wiki
+4. ✨ Run the tests to make sure everything works
+5. 🔖 Commit & push your changes
+6. 🔁 Open a PR to get your changes merged
+7. 🚀 Profit!
+
+👩‍⚖️ When contributing code to this project, you must agree that you have authored
+100% of the content, that you have the necessary rights to the content and that
+the content you contribute may be provided under the project license.
+
+<!-- prettier-ignore-start -->
+[how to add a feature]: https://github.com/devcontainers-contrib/features/wiki/How-to-add-a-feature
+<!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -1,77 +1,89 @@
 # Community devcontainer features
 
-[![Gitter](https://img.shields.io/gitter/room/devcontainers-contrib/community?style=for-the-badge&logo=appveyor)](https://gitter.im/devcontainers-contrib/community)
-![Codespaces](https://img.shields.io/static/v1?style=for-the-badge&message=Codespaces&color=181717&logo=GitHub&logoColor=FFFFFF&label=)
-![Devcontainers](https://img.shields.io/static/v1?style=for-the-badge&message=Devcontainers&color=2496ED&logo=Docker&logoColor=FFFFFF&label=)
-![Python](https://img.shields.io/static/v1?style=for-the-badge&message=Python&color=3776AB&logo=Python&logoColor=FFFFFF&label=)
-
-🐳 Extra add-in features for
-[devcontainers](https://code.visualstudio.com/docs/devcontainers/containers) and
-[GitHub Codespaces](https://github.com/features/codespaces)
+🧰 Feature addons for [@devcontainers]
 
 <div align="center">
 
-![](https://i.imgur.com/W7t3YsC.png)
+![](https://i.imgur.com/VgiY81S.png)
 
-**[Overview](https://github.com/devcontainers-contrib/features#readme)** |
-[User docs](https://github.com/devcontainers-contrib/features#usage) |
-[Contributing](https://github.com/devcontainers-contrib/features/blob/main/CONTRIBUTING.md)
-| [Developer wiki](https://github.com/devcontainers-contrib/features/wiki)
+<!-- prettier-ignore -->
+[How to use a feature](https://code.visualstudio.com/blogs/2022/09/15/dev-container-features#_adding-features-to-your-dev-container)
+| [List of features](https://github.com/devcontainers-contrib/features/tree/main/src) <!-- CHANGE THIS TO GITHUB PAGES WHEN #284 IS MERGED! -->
+| [Contributing](https://github.com/devcontainers-contrib/features/blob/main/CONTRIBUTING.md)
+| [Dev wiki](https://github.com/devcontainers-contrib/features/wiki)
+| [Chat](https://gitter.im/devcontainers-contrib/community)
 
 </div>
 
-💻 Works with
-[devcontainers](https://code.visualstudio.com/docs/devcontainers/containers) \
-☁️ Works with [GitHub Codespaces](https://github.com/features/codespaces) \
+💻 Works with [devcontainers] \
+☁️ Works with [GitHub Codespaces] \
+⚠️ We only officially support [debian]-based images
 
-📢 [We are actively seeking contributions!](CONTRIBUTING.md)
-
-
-## Contributing guide 😊
-
-## A Handcrafted Feature
-
-- Add a feature-id named directory to the [src folder](src/) containing  your `devcontainer-feature.json` and `install.sh` scripts
-- Add the corresponsing test.sh to the [test folder](tests/)
-
-## An Easily Generated Feature
-
-Get the devcontainer-contrib cli 
-```shell 
-pip install devcontainer-contrib
-```
-
-Add a new [`devcontainer-definition.json`](https://github.com/devcontainers-contrib/cli#readme) file to the [feature_definition dir](feature_definitions/) 
-
-While under the root folder of this repo, generate it using the command:
-```shell
-devcontainer-contrib features generate "./feature_definition/your-feature-id/feature-definition.json" "." --output-type=feature_dir
-```
-
-[Additional information and docs about the CLI and devcontainer-definition.json file](https://github.com/devcontainers-contrib/cli#readme)
-
+👀 Don't see your feature here? [Add it yourself] or [open an Issue]!
 
 ## Usage
 
+![VS Code](https://img.shields.io/static/v1?style=for-the-badge&message=VS+Code&color=007ACC&logo=Visual+Studio+Code&logoColor=FFFFFF&label=)
+![Codespaces](https://img.shields.io/static/v1?style=for-the-badge&message=Codespaces&color=181717&logo=GitHub&logoColor=FFFFFF&label=)
+![Devcontainers](https://img.shields.io/static/v1?style=for-the-badge&message=Devcontainers&color=2496ED&logo=Docker&logoColor=FFFFFF&label=)
 
-📄 [View the full list of features](src/)
+📄 [Complete feature list]
 
 Just add a `.devcontainer/devcontainer.json` file with a `features` key. It's
-very similar to NPM's `package.json` and `dependencies` object, just with the
-addition of an `options` object.
+very similar to `package.json`'s `dependencies` object, just with the addition
+of an `options` object.
 
-📚 Make sure to inspect each feature for feature-specific options \
-⚠️ We only officially support [debian](https://hub.docker.com/_/debian)-based images
+📚 Make sure to inspect each feature for feature-specific options!
 
 ```json
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:linux",
+  "image": "mcr.microsoft.com/devcontainers/universal",
   "features": {
-    "ghcr.io/devcontainers-contrib/features/deno:latest": {},
-    "ghcr.io/devcontainers-contrib/features/mkdocs:latest": {},
-    "ghcr.io/devcontainers-contrib/features/bikeshed:latest": {}
+    "ghcr.io/devcontainers-contrib/features/deno:": {},
+    "ghcr.io/devcontainers-contrib/features/neovim": {}
   }
 }
 ```
 
-## You can find more developer-specific docs on the [Wiki!](https://github.com/devcontainers-contrib/features/wiki) (thank you [@jcbhmr](https://github.com/jcbhmr)!)
+Then, after adding your devcontainer config file, you can open it in GitHub
+Codespaces, or [open it locally using VS Code]. Be warned some features will
+compile things from source code and may take a while!
+
+<div align="center">
+
+![](https://i.imgur.com/JMdowst.png)
+
+</div>
+
+## Development
+
+![Devcontainers](https://img.shields.io/static/v1?style=for-the-badge&message=Devcontainers&color=2496ED&logo=Docker&logoColor=FFFFFF&label=)
+![JSON](https://img.shields.io/static/v1?style=for-the-badge&message=JSON&color=000000&logo=JSON&logoColor=FFFFFF&label=)
+![Bash](https://img.shields.io/static/v1?style=for-the-badge&message=Bash&color=4EAA25&logo=GNU+Bash&logoColor=FFFFFF&label=)
+
+➕ Looking to add a new feature? Check out the [contributing guide]!
+
+This project uses a devcontainer config to outline the development environment.
+We also provide various VS Code customizations for your coding pleasure.
+
+To get started, create a GitHub Codespace on a copy of this repository. From
+there, the [dev wiki] provides information about adding features, layout,
+conventions, etc. When or if you want to contribute your changes back to this
+repository, you can follow the [contributing guide]. Happy coding! 👋
+
+🗺️ If you're looking for a more thorough outline of how this repo works, check
+out the [How it works] page on the dev wiki.
+
+<!-- prettier-ignore-start -->
+[@devcontainers]: https://github.com/devcontainers
+[add it yourself]: https://github.com/devcontainers-contrib/features/wiki/How-to-add-a-feature
+[open an issue]: https://github.com/devcontainers-contrib/features/issues/new
+[complete feature list]: https://github.com/devcontainers-contrib/features/tree/main/src
+[debian]: https://hub.docker.com/_/debian
+[open it locally using vs code]: https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container
+[contributing guide]: CONTRIBUTING.md
+[how it works]: https://github.com/devcontainers-contrib/features/wiki/How-it-works
+[dev wiki]: https://github.com/devcontainers-contrib/features/wiki
+[devcontainers]: https://containers.dev/
+[github codespaces]: https://github.com/features/codespaces
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
Fixes part of #286 

This PR would... (checkboxes track draft progress)
- [x] Add a better header image to the readme
- [x] Reformat the navbar to be "quicklinks" instead of "navlinks"
- [x] Change description from "🐳 Extra add-in features for devcontainers and GitHub Codespaces" to "🧰 Feature addons for @devcontainers"
- [x] Change up the emoji bullet list of features/highlights
- [x] Make the call to contribute more interesting
- [x] Remove weird heading about seeing the dev wiki
- [x] Add example of using GitHub Codespaces
- [x] Add short development section
- [x] Add short "adding a feature" guide in CONTRIBUTING.md
- [x] Reword the "I want to..." list in CONTRIBUTING.md

@danielbraun89 You'll need to change the tags and description of this actual repo on GitHub since you're the only one with that power.