### PR TITLE
fix: ansible installAfter version pinning

### DIFF
--- a/feature_definitions/ansible/feature-definition.json
+++ b/feature_definitions/ansible/feature-definition.json
@@ -15,8 +15,8 @@
         }
     },
     "installsAfter": [
-        "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.3",
-        "ghcr.io/devcontainers/features/python:1.0.18"
+        "ghcr.io/devcontainers-contrib/features/pipx-package",
+        "ghcr.io/devcontainers/features/python"
     ],
     "dependencies": [
         {

--- a/src/ansible/devcontainer-feature.json
+++ b/src/ansible/devcontainer-feature.json
@@ -15,7 +15,7 @@
         }
     },
     "installsAfter": [
-        "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.3",
-        "ghcr.io/devcontainers/features/python:1.0.18"
+        "ghcr.io/devcontainers-contrib/features/pipx-package",
+        "ghcr.io/devcontainers/features/python"
     ]
 }


### PR DESCRIPTION
This fixes #301 for ansible.
It could probably be applied to the other packages and produce the desired effect.