### PR TITLE
fix: pnpm feature - update featmake version to solve alpine misdetection issue

### DIFF
--- a/src/pnpm/dependencies.sh
+++ b/src/pnpm/dependencies.sh
@@ -16,8 +16,8 @@ ensure_featmake () {
         temp_dir=/tmp/featmake-download
         mkdir -p $temp_dir
 
-        curl -sSL -o $temp_dir/featmake https://github.com/devcontainers-contrib/cli/releases/download/v0.0.18/featmake 
-        curl -sSL -o $temp_dir/checksums.txt https://github.com/devcontainers-contrib/cli/releases/download/v0.0.18/checksums.txt
+        curl -sSL -o $temp_dir/featmake https://github.com/devcontainers-contrib/cli/releases/download/v0.0.19/featmake 
+        curl -sSL -o $temp_dir/checksums.txt https://github.com/devcontainers-contrib/cli/releases/download/v0.0.19/checksums.txt
 
         (cd $temp_dir ; sha256sum --check --strict $temp_dir/checksums.txt)
 

--- a/src/pnpm/devcontainer-feature.json
+++ b/src/pnpm/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "pnpm",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "name": "Pnpm (via npm)",
     "documentationURL": "http://github.com/devcontainers-contrib/features/tree/main/src/pnpm",
     "description": "Pnpm is a fast and disk space efficient package manager.",


### PR DESCRIPTION
### Issue

`pnpm` feature fails to install in Ubuntu images as it is using an old `featmake` version with a known issue.

### Detail

`featmake v0.0.18` had an issue (see #281) that meant Ubuntu was being incorrectly detected as Alpine, causing feature installations to fail. This was fixed in `v0.0.19` (see #282), and most features were upgraded in #283.

The `pnpm` feature is still using `v0.0.18`. This means it fails to install in an Ubuntu image with the error `apk: command not found`.

### PR

This PR bumps the version of `featmake` used in the `pnpm` feature to `0.0.19`. This brings this feature in line with others using `featmake` and solves the install error when using with Ubuntu images.

### Testing

Feature was failing tests before changes. Verified that `pnpm` feature now passes tests with the following command:

```
devcontainer features test -f pnpm -i "mcr.microsoft.com/devcontainers/base:ubuntu"
```

Additionally, manually tested by self-installing feature locally in an Ubuntu image, verifying that installation completed, and the `pnpm` cli was available once the container started.