### PR TITLE
Reverse order of Elixir and Erlang

### DIFF
--- a/src/elixir-asdf/install.sh
+++ b/src/elixir-asdf/install.sh
@@ -23,14 +23,14 @@ $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-contrib/features/asdf-package:1.0.5" \
-    --option plugin='elixir' --option version="$ELIXIRVERSION"
+    --option plugin='erlang' --option version="$ERLANGVERSION"
 
 
 $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-contrib/features/asdf-package:1.0.5" \
-    --option plugin='erlang' --option version="$ERLANGVERSION"
+    --option plugin='elixir' --option version="$ELIXIRVERSION"
 
 
 echo 'Done!'


### PR DESCRIPTION
Erlang needs to be installed before Elixir in order to use [default mix commands](https://github.com/asdf-vm/asdf-elixir#default-mix-commands).

<!-- Thanks for contributing! ❤️ -->
