### PR TITLE
Add dind for localstack devcontainer-feature.json installsAfter

### DIFF
--- a/src/localstack/devcontainer-feature.json
+++ b/src/localstack/devcontainer-feature.json
@@ -17,6 +17,7 @@
     "installsAfter": [
         "ghcr.io/devcontainers-contrib/features/apt-get-packages",
         "ghcr.io/devcontainers-contrib/features/pipx-package",
-        "ghcr.io/devcontainers/features/python"
+        "ghcr.io/devcontainers/features/python",
+        "ghcr.io/devcontainers/features/docker-in-docker"
     ]
 }


### PR DESCRIPTION
### Reason for Change
In order for `localstack start` to work in a devcontainer, it seems to require `docker-in-docker`, so thought it would make sense to be added into the `installsAfter` section of the `devcontainer-feature.json` for `localstack`.

### Testing
```
vscode@b715ab76b309:/workspaces/features$ devcontainer features test --features localstack

┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
|    Dev Container Features   |   
│           v0.41.0           │
└ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘

>  baseImage:         ubuntu:focal
>  Target Folder:     /workspaces/features
>  features:          localstack
>  workspaceFolder:   /tmp/devcontainercli/container-features-test/1682865791975

⏳ Building test container...

[0 ms] @devcontainers/cli 0.41.0. Node.js v18.16.0. linux 5.15.49-linuxkit arm64.
[1352 ms] [httpOci] Failed to execute credential helper dev-containers-fbebb0e4-1e37-41b0-8cb0-2248136955da
[5774 ms] Start: Run: docker buildx build --load --build-context dev_containers_feature_content_source=/tmp/devcontainercli-vscode/container-features/0.41.0-1682865797796 --build-arg _DEV_CONTAINERS_BASE_IMAGE=ubuntu:focal --build-arg _DEV_CONTAINERS_IMAGE_USER=root --build-arg _DEV_CONTAINERS_FEATURE_CONTENT_SOURCE=dev_container_feature_content_temp --target dev_containers_target_stage -t vsc-1682865791975-2a464afc7cdd4422575ddbcd3eba3e016c235dd7a3a7e5a9b42bf8d054a91708-features -f /tmp/devcontainercli-vscode/container-features/0.41.0-1682865797796/Dockerfile.extended /tmp/devcontainercli-vscode/empty-folder
[+] Building 2.5s (17/17) FINISHED                                              
 => [internal] load build definition from Dockerfile.extended              0.0s
 => => transferring dockerfile: 1.44kB                                     0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => resolve image config for docker.io/docker/dockerfile:1.4               1.1s
 => CACHED docker-image://docker.io/docker/dockerfile:1.4@sha256:9ba7531b  0.0s
 => [internal] load build definition from Dockerfile.extended              0.0s
 => [internal] load .dockerignore                                          0.0s
 => [internal] load metadata for docker.io/library/ubuntu:focal            1.1s
 => [context dev_containers_feature_content_source] load .dockerignore     0.0s
 => => transferring dev_containers_feature_content_source: 2B              0.0s
 => [context dev_containers_feature_content_source] load from client       0.0s
 => => transferring dev_containers_feature_content_source: 11.15kB         0.0s
 => [dev_containers_feature_content_normalize 1/3] FROM docker.io/library  0.0s
 => CACHED [dev_containers_target_stage 2/5] RUN mkdir -p /tmp/dev-contai  0.0s
 => CACHED [dev_containers_feature_content_normalize 2/3] COPY --from=dev  0.0s
 => CACHED [dev_containers_feature_content_normalize 3/3] RUN chmod -R 07  0.0s
 => CACHED [dev_containers_target_stage 3/5] COPY --from=dev_containers_f  0.0s
 => CACHED [dev_containers_target_stage 4/5] RUN echo "_CONTAINER_USER_HO  0.0s
 => CACHED [dev_containers_target_stage 5/5] RUN --mount=type=bind,from=d  0.0s
 => exporting to image                                                     0.0s
 => => exporting layers                                                    0.0s
 => => writing image sha256:325f398e02018f34eb2cffbf94acb3ef84ba5c8a8a9bc  0.0s
 => => naming to docker.io/library/vsc-1682865791975-2a464afc7cdd4422575d  0.0s
[8515 ms] Start: Run: docker run --sig-proxy=false -a STDOUT -a STDERR --mount type=bind,source=/tmp/devcontainercli/container-features-test/1682865791975,target=/workspaces/1682865791975 -l devcontainer.local_folder=/tmp/devcontainercli/container-features-test/1682865791975 -l devcontainer.is_test_run=true --entrypoint /bin/sh vsc-1682865791975-2a464afc7cdd4422575ddbcd3eba3e016c235dd7a3a7e5a9b42bf8d054a91708-features -c echo Container started
Container started

🚀 Launched container.
>  containerId:          d4dd7f98abb149cadd41e8179b60a86efbbc8be45bf1e23e9b2246a6b3fd2eff

🏃 Starting test(s)...

🧪 Starting 'localstack' tests...


🔄 Testing 'localstack --version'

2.0.2


✅  Passed 'localstack --version'!


Test Passed!
🧪 Executing scenarios for feature 'localstack'...
>  Running scenario:  test
>  workspaceFolder:   /tmp/devcontainercli/container-features-test/1682865801355

⏳ Building test container...

[1 ms] @devcontainers/cli 0.41.0. Node.js v18.16.0. linux 5.15.49-linuxkit arm64.
[992 ms] Start: Run: docker buildx build --load --build-context dev_containers_feature_content_source=/tmp/devcontainercli-vscode/container-features/0.41.0-1682865802408 --build-arg _DEV_CONTAINERS_BASE_IMAGE=mcr.microsoft.com/devcontainers/base:debian --build-arg _DEV_CONTAINERS_IMAGE_USER=root --build-arg _DEV_CONTAINERS_FEATURE_CONTENT_SOURCE=dev_container_feature_content_temp --target dev_containers_target_stage -t vsc-1682865801355-418d6b6bd0da0acb4d69250b8c765722b74a3b061fd711d588b9ec05d495e87c-features -f /tmp/devcontainercli-vscode/container-features/0.41.0-1682865802408/Dockerfile.extended /tmp/devcontainercli-vscode/empty-folder
[+] Building 0.9s (16/17)                                                       
 => [internal] load build definition from Dockerfile.extended              0.0s
 => => transferring dockerfile: 1.60kB                                     0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => resolve image config for docker.io/docker/dockerfile:1.4               0.5s
 => CACHED docker-image://docker.io/docker/dockerfile:1.4@sha256:9ba7531b  0.0s
 => [internal] load build definition from Dockerfile.extended              0.0s
 => [internal] load .dockerignore                                          0.0s
 => [internal] load metadata for mcr.microsoft.com/devcontainers/base:deb  0.2s
 => [context dev_containers_feature_content_source] load .dockerignore     0.0s
 => => transferring dev_containers_feature_content_source: 2B              0.0s
 => [context dev_containers_feature_content_source] load from client       0.0s
 => => transferring dev_containers_feature_content_source: 11.30kB         0.0s
 => [dev_containers_feature_content_normalize 1/3] FROM mcr.microsoft.com  0.0s
 => CACHED [dev_containers_target_stage 2/5] RUN mkdir -p /tmp/dev-contai  0.0s
 => CACHED [dev_containers_feature_content_normalize 2/3] COPY --from=dev  0.0s
 => CACHED [dev_containers_feature_content_normalize 3/3] RUN chmod -R 07  0.0s
 => CACHED [dev_containers_target_stage 3/5] COPY --from=dev_containers_f  0.0s
 => CACHED [dev_containers_target_stage 4/5] RUN echo "_CONTAINER_USER_HO  0.0s
 => CACHED [dev_containers_target_stage 5/5] RUN --mount=type=bind,from=d  0.0s
 => exporting to image                                                     0.0s
 => => exporting layers                                                    0.0s
 => => writing image sha256:68e3d8caa99bd0dfe08f12306a917b571796e05f56e06  0.0s
 => => naming to docker.io/library/vsc-1682865801355-418d6b6bd0da0acb4d69  0.0s
[2393 ms] Start: Run: docker run --sig-proxy=false -a STDOUT -a STDERR --mount type=bind,source=/tmp/devcontainercli/container-features-test/1682865801355,target=/workspaces/1682865801355 -l devcontainer.local_folder=/tmp/devcontainercli/container-features-test/1682865801355 -l devcontainer.is_test_run=true --entrypoint /bin/sh vsc-1682865801355-418d6b6bd0da0acb4d69250b8c765722b74a3b061fd711d588b9ec05d495e87c-features-uid -c echo Container started
Container started

🚀 Launched container.
>  containerId:          09622e265fa6cb9988f83e3a289dc260ffb1ead4c991a3de878466b62b7143b0


🔄 Testing 'localstack --version'

2.0.2


✅  Passed 'localstack --version'!


Test Passed!
🧹 Cleaning up 2 test containers...
🧹 Removing container 09622e265fa6...
🧹 Removing container d4dd7f98abb1...



  ================== TEST REPORT ==================
✅ Passed:      'localstack'
✅ Passed:      'test'

```


<!-- Thanks for contributing! ❤️ -->
