### PR TITLE
refactor(zsh-plugins): Clone only the latest commit

### DIFF
--- a/src/zsh-plugins/devcontainer-feature.json
+++ b/src/zsh-plugins/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "ZSH Plugins",
   "id": "zsh-plugins",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Install (Oh-My-)ZSH plugins",
   "documentationURL": "http://github.com/devcontainers-contrib/features/tree/main/src/zsh-plugins",
   "installsAfter": [

--- a/src/zsh-plugins/install.sh
+++ b/src/zsh-plugins/install.sh
@@ -22,7 +22,7 @@ IFS=' ' read -ra plugins <<< "${OMZSH_PLUGINS}"
 
 for plugin in "${plugins[@]}"
 do
-  git clone $plugin
+  git clone --depth 1 $plugin
 done
 
 cd "$currdir" || exit


### PR DESCRIPTION
There is no need to clone the full Git tree in this situation because we are only interested in the latest commit on the default branch.
This brings a small performance increase.

<!-- Thanks for contributing! ❤️ -->
