### PR TITLE
Optional install of mixins

### DIFF
--- a/src/porter/devcontainer-feature.json
+++ b/src/porter/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "porter",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "Porter (via porter.sh)",
     "documentationURL": "http://github.com/devcontainers-contrib/features/tree/main/src/porter",
     "description": "Porter enables you to package your application artifact, client tools, configuration and deployment logic together as an installer that you can distribute, and install with a single command.",

--- a/src/porter/devcontainer-feature.json
+++ b/src/porter/devcontainer-feature.json
@@ -1,20 +1,20 @@
 {
     "id": "porter",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Porter (via porter.sh)",
     "documentationURL": "http://github.com/devcontainers-contrib/features/tree/main/src/porter",
     "description": "Porter enables you to package your application artifact, client tools, configuration and deployment logic together as an installer that you can distribute, and install with a single command.",
     "options": {
         "version": {
             "default": "latest",
-            "description": "Select the version to install.",
+            "description": "Select the version to install. Empty string installs the latest version.",
             "proposals": [
                 "latest"
             ],
             "type": "string"
         },
         "terraformMixinVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the terraform mixin version to install.",
             "proposals": [
                 "latest"
@@ -22,7 +22,7 @@
             "type": "string"
         },
         "azMixinVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the az mixin version to install.",
             "proposals": [
                 "latest"
@@ -30,7 +30,7 @@
             "type": "string"
         },
         "awsMixinVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the aws mixin version to install.",
             "proposals": [
                 "latest"
@@ -38,7 +38,7 @@
             "type": "string"
         },
         "dockerMixinVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the docker mixin version to install.",
             "proposals": [
                 "latest"
@@ -46,7 +46,7 @@
             "type": "string"
         },
         "dockerComposeMixinVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the docker-compose mixin version to install.",
             "proposals": [
                 "latest"
@@ -54,7 +54,7 @@
             "type": "string"
         },
         "gcloudMixinVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the gcloud mixin version to install.",
             "proposals": [
                 "latest"
@@ -62,7 +62,7 @@
             "type": "string"
         },
         "helmMixinVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the helm mixin version to install.",
             "proposals": [
                 "latest"
@@ -70,7 +70,7 @@
             "type": "string"
         },
         "armMixinVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the arm mixin version to install.",
             "proposals": [
                 "latest"
@@ -78,7 +78,7 @@
             "type": "string"
         },
         "azurePluginVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the azure plugin version to install.",
             "proposals": [
                 "latest"
@@ -86,7 +86,7 @@
             "type": "string"
         },
         "kubernetesPluginVersion": {
-            "default": "latest",
+            "default": "",
             "description": "Select the kubernetes plugin version to install.",
             "proposals": [
                 "latest"

--- a/src/porter/install.sh
+++ b/src/porter/install.sh
@@ -11,6 +11,11 @@ source ./library_scripts.sh
 # of the script
 ensure_nanolayer nanolayer_location "v0.4.39"
 
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-contrib/features/apt-get-packages:1.0.4" \
+    --option packages='curl'
 
 $nanolayer_location \
     install \
@@ -19,94 +24,92 @@ $nanolayer_location \
     --option command='curl -L https://cdn.porter.sh/latest/install-linux.sh | PORTER_VERSION=$VERSION PORTER_HOME=/usr/local/porter bash -s -- -x'
     
 
-
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter mixin install terraform --version $TERRAFORMMIXINVERSION'
-    
-
-
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter mixin install az --version $AZMIXINVERSION'
-    
+if [ -n "$TERRAFORMMIXINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter mixin install terraform --version $TERRAFORMMIXINVERSION'
+fi
 
 
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter mixin install aws --version $AWSMIXINVERSION'
-    
+if [ -n "$AZMIXINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter mixin install az --version $AZMIXINVERSION'
+fi    
 
+if [ -n "$AWSMIXINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter mixin install aws --version $AWSMIXINVERSION'
+fi    
 
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter mixin install docker --version $DOCKERMIXINVERSION'
-    
+if [ -n "$DOCKERMIXINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter mixin install docker --version $DOCKERMIXINVERSION'
+fi    
 
+if [ -n "$DOCKERCOMPOSEMIXINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter mixin install docker-compose --version $DOCKERCOMPOSEMIXINVERSION'
+fi    
 
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter mixin install docker-compose --version $DOCKERCOMPOSEMIXINVERSION'
-    
+if [ -n "$GCLOUDMIXINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter mixin install gcloud --version $GCLOUDMIXINVERSION'
+fi    
 
+if [ -n "$HELMMIXINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter mixin install helm --version $HELMMIXINVERSION'
+fi    
 
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter mixin install gcloud --version $GCLOUDMIXINVERSION'
-    
+if [ -n "$ARMMIXINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter mixin install arm --version $ARMMIXINVERSION'
+fi    
 
+if [ -n "$AZUREPLUGINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter plugin install azure --version $AZUREPLUGINVERSION'
+fi    
 
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter mixin install helm --version $HELMMIXINVERSION'
-    
-
-
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter mixin install arm --version $ARMMIXINVERSION'
-    
-
-
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter plugin install azure --version $AZUREPLUGINVERSION'
-    
-
-
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
-    --option command='/usr/local/porter/porter plugin install kubernetes --version $KUBERNETESPLUGINVERSION'
-    
-
+if [ -n "$KUBERNETESPLUGINVERSION" ] ; then
+    $nanolayer_location \
+        install \
+        devcontainer-feature \
+        "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
+        --option command='/usr/local/porter/porter plugin install kubernetes --version $KUBERNETESPLUGINVERSION'
+fi    
 
 $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-contrib/features/bash-command:1.0.0" \
     --option command='chown -hR ${_REMOTE_USER}:${_REMOTE_USER} /usr/local/porter'
-    
 
 
 echo 'Done!'
-

--- a/test/porter/install_mixins.sh
+++ b/test/porter/install_mixins.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -i
+
+set -e
+
+source dev-container-features-test-lib
+
+check "porter --version" porter --version
+
+check "exec mixin installed" "$PORTER_HOME"/mixins/exec/exec version
+check "terraform mixin installed" "$PORTER_HOME"/mixins/terraform/terraform version
+check "az mixin installed" "$PORTER_HOME"/mixins/az/az version
+check "docker mixin installed" "$PORTER_HOME"/mixins/docker/docker version
+check "docker-compose mixin installed" "$PORTER_HOME"/mixins/docker-compose/docker-compose version
+check "gcloud mixin installed" "$PORTER_HOME"/mixins/gcloud/gcloud version
+check "helm mixin installed" "$PORTER_HOME"/mixins/helm/helm version
+check "arm mixin installed" "$PORTER_HOME"/mixins/arm/arm version
+check "azure plugin installed" "$PORTER_HOME"/plugins/azure/azure version
+check "kubernetes plugin installed" "$PORTER_HOME"/plugins/kubernetes/kubernetes version
+
+reportResults

--- a/test/porter/install_mixins.sh
+++ b/test/porter/install_mixins.sh
@@ -6,6 +6,30 @@ source dev-container-features-test-lib
 
 check "porter --version" porter --version
 
+# Old check with grep
+check "porter mixin list | grep terraform" porter mixin list | grep terraform
+
+check "porter mixin list | grep az" porter mixin list | grep az
+
+check "porter mixin list | grep aws" porter mixin list | grep aws
+
+check "porter mixin list | grep docker" porter mixin list | grep docker
+
+check "porter mixin list | grep docker-compose" porter mixin list | grep docker-compose
+
+check "porter mixin list | grep gcloud" porter mixin list | grep gcloud
+
+check "porter mixin list | grep helm" porter mixin list | grep helm
+
+check "porter mixin list | grep arm" porter mixin list | grep arm
+
+check "porter plugin list | grep azure" porter plugin list | grep azure
+
+check "porter plugin list | grep kubernetes" porter plugin list | grep kubernetes
+
+# Check File permissions in GH Actions. (Works locally, but not in GH Actions)
+ls -al "$PORTER_HOME/mixins/exec"
+
 check "exec mixin installed" "$PORTER_HOME"/mixins/exec/exec version
 check "terraform mixin installed" "$PORTER_HOME"/mixins/terraform/terraform version
 check "az mixin installed" "$PORTER_HOME"/mixins/az/az version

--- a/test/porter/install_mixins.sh
+++ b/test/porter/install_mixins.sh
@@ -4,32 +4,12 @@ set -e
 
 source dev-container-features-test-lib
 
+echo "User: $(id)"
+ls -al "$PORTER_HOME"
+
 check "porter --version" porter --version
 
-# Old check with grep
-check "porter mixin list | grep terraform" porter mixin list | grep terraform
-
-check "porter mixin list | grep az" porter mixin list | grep az
-
-check "porter mixin list | grep aws" porter mixin list | grep aws
-
-check "porter mixin list | grep docker" porter mixin list | grep docker
-
-check "porter mixin list | grep docker-compose" porter mixin list | grep docker-compose
-
-check "porter mixin list | grep gcloud" porter mixin list | grep gcloud
-
-check "porter mixin list | grep helm" porter mixin list | grep helm
-
-check "porter mixin list | grep arm" porter mixin list | grep arm
-
-check "porter plugin list | grep azure" porter plugin list | grep azure
-
-check "porter plugin list | grep kubernetes" porter plugin list | grep kubernetes
-
-# Check File permissions in GH Actions. (Works locally, but not in GH Actions)
-ls -al "$PORTER_HOME/mixins/exec"
-
+# Exec mixin should be installed by default
 check "exec mixin installed" "$PORTER_HOME"/mixins/exec/exec version
 check "terraform mixin installed" "$PORTER_HOME"/mixins/terraform/terraform version
 check "az mixin installed" "$PORTER_HOME"/mixins/az/az version

--- a/test/porter/scenarios.json
+++ b/test/porter/scenarios.json
@@ -1,8 +1,19 @@
 {
-    "test": {
+    "install_mixins": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
-            "porter": {}
+            "porter": {
+                "terraformMixinVersion": "latest",
+                "azMixinVersion": "latest",
+                "awsMixinVersion": "latest",
+                "dockerMixinVersion": "latest",
+                "dockerComposeMixinVersion": "latest",
+                "gcloudMixinVersion": "latest",
+                "helmMixinVersion": "latest",
+                "armMixinVersion": "latest",
+                "azurePluginVersion": "latest",
+                "kubernetesPluginVersion": "latest"
+            }
         }
     }
 }

--- a/test/porter/scenarios.json
+++ b/test/porter/scenarios.json
@@ -14,6 +14,7 @@
                 "azurePluginVersion": "latest",
                 "kubernetesPluginVersion": "latest"
             }
-        }
+        },
+        "remoteUser": "vscode"
     }
 }

--- a/test/porter/scenarios.json
+++ b/test/porter/scenarios.json
@@ -15,6 +15,7 @@
                 "kubernetesPluginVersion": "latest"
             }
         },
-        "remoteUser": "vscode"
+        // This will fail if you use `vscode`
+        "remoteUser": 1000
     }
 }

--- a/test/porter/test.sh
+++ b/test/porter/test.sh
@@ -6,24 +6,9 @@ source dev-container-features-test-lib
 
 check "porter --version" porter --version
 
-check "porter mixin list | grep terraform" porter mixin list | grep terraform
+# Exec mixin should be installed by default
+check "exec mixin installed" "$PORTER_HOME"/mixins/exec/exec version
 
-check "porter mixin list | grep az" porter mixin list | grep az
-
-check "porter mixin list | grep aws" porter mixin list | grep aws
-
-check "porter mixin list | grep docker" porter mixin list | grep docker
-
-check "porter mixin list | grep docker-compose" porter mixin list | grep docker-compose
-
-check "porter mixin list | grep gcloud" porter mixin list | grep gcloud
-
-check "porter mixin list | grep helm" porter mixin list | grep helm
-
-check "porter mixin list | grep arm" porter mixin list | grep arm
-
-check "porter plugin list | grep azure" porter plugin list | grep azure
-
-check "porter plugin list | grep kubernetes" porter plugin list | grep kubernetes
+check "List all mixins" "$PORTER_HOME"/porter mixins list
 
 reportResults


### PR DESCRIPTION
Porter mixin/plugin installation should be optional. If an empty string is submitted in the version field of each mixin, it will not install.

I also found that curl was not installed when running the tests locally.

When testing for the mixins or plugins, you can call the "version" command on each to test if it is installed.