### PR TITLE
Typo fix: `varialbe` -> `variable`

### DIFF
--- a/src/act-asdf/library_scripts.sh
+++ b/src/act-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/act/library_scripts.sh
+++ b/src/act/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/actionlint/library_scripts.sh
+++ b/src/actionlint/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/actions-runner-noexternals/library_scripts.sh
+++ b/src/actions-runner-noexternals/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/actions-runner-noruntime-noexternals/library_scripts.sh
+++ b/src/actions-runner-noruntime-noexternals/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/actions-runner-noruntime/library_scripts.sh
+++ b/src/actions-runner-noruntime/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/actions-runner/library_scripts.sh
+++ b/src/actions-runner/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/activemq-sdkman/library_scripts.sh
+++ b/src/activemq-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/age-keygen/library_scripts.sh
+++ b/src/age-keygen/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/age/library_scripts.sh
+++ b/src/age/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/airplane-cli/library_scripts.sh
+++ b/src/airplane-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/akamai-cli/library_scripts.sh
+++ b/src/akamai-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/alertmanager/library_scripts.sh
+++ b/src/alertmanager/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/alp-asdf/library_scripts.sh
+++ b/src/alp-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/amplify-cli/library_scripts.sh
+++ b/src/amplify-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/angular-cli/library_scripts.sh
+++ b/src/angular-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ansible/library_scripts.sh
+++ b/src/ansible/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ant-sdkman/library_scripts.sh
+++ b/src/ant-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/apko/library_scripts.sh
+++ b/src/apko/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/apt-get-packages/library_scripts.sh
+++ b/src/apt-get-packages/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/apt-packages/library_scripts.sh
+++ b/src/apt-packages/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/asciidoctorj-sdkman/library_scripts.sh
+++ b/src/asciidoctorj-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/assemblyscript/library_scripts.sh
+++ b/src/assemblyscript/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/atlantis/library_scripts.sh
+++ b/src/atlantis/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/atmos/library_scripts.sh
+++ b/src/atmos/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/auditjs/library_scripts.sh
+++ b/src/auditjs/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/autoenv/library_scripts.sh
+++ b/src/autoenv/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/aws-cdk/library_scripts.sh
+++ b/src/aws-cdk/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/aws-eb-cli/library_scripts.sh
+++ b/src/aws-eb-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/aztfexport/library_scripts.sh
+++ b/src/aztfexport/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ballerina-sdkman/library_scripts.sh
+++ b/src/ballerina-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/bandit/library_scripts.sh
+++ b/src/bandit/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/bartib/library_scripts.sh
+++ b/src/bartib/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/beehive/library_scripts.sh
+++ b/src/beehive/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/bigcommerce-stencil-cli/library_scripts.sh
+++ b/src/bigcommerce-stencil-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/bikeshed/library_scripts.sh
+++ b/src/bikeshed/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/bin/library_scripts.sh
+++ b/src/bin/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/bitwarden-cli/library_scripts.sh
+++ b/src/bitwarden-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/black/library_scripts.sh
+++ b/src/black/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/blackbox-exporter/library_scripts.sh
+++ b/src/blackbox-exporter/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/bomber/library_scripts.sh
+++ b/src/bomber/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/boundary-asdf/library_scripts.sh
+++ b/src/boundary-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/bower/library_scripts.sh
+++ b/src/bower/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/bpipe-sdkman/library_scripts.sh
+++ b/src/bpipe-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/brownie/library_scripts.sh
+++ b/src/brownie/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/browserify/library_scripts.sh
+++ b/src/browserify/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/btm/library_scripts.sh
+++ b/src/btm/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/btop-homebrew/library_scripts.sh
+++ b/src/btop-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/btrace-sdkman/library_scripts.sh
+++ b/src/btrace-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/budibase-cli/library_scripts.sh
+++ b/src/budibase-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/buku/library_scripts.sh
+++ b/src/buku/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/caddy/library_scripts.sh
+++ b/src/caddy/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ccache-asdf/library_scripts.sh
+++ b/src/ccache-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cert-manager/library_scripts.sh
+++ b/src/cert-manager/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/checkov/library_scripts.sh
+++ b/src/checkov/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/chezscheme-asdf/library_scripts.sh
+++ b/src/chezscheme-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/chisel/library_scripts.sh
+++ b/src/chisel/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/circleci-cli/library_scripts.sh
+++ b/src/circleci-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/clojure-asdf/library_scripts.sh
+++ b/src/clojure-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cloud-nuke/library_scripts.sh
+++ b/src/cloud-nuke/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cloudflare-wrangler/library_scripts.sh
+++ b/src/cloudflare-wrangler/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cloudflared-fips/library_scripts.sh
+++ b/src/cloudflared-fips/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cloudflared/library_scripts.sh
+++ b/src/cloudflared/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cloudinary-cli/library_scripts.sh
+++ b/src/cloudinary-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cmctl-asdf/library_scripts.sh
+++ b/src/cmctl-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/codefresh-cli/library_scripts.sh
+++ b/src/codefresh-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/codenotary-cas/library_scripts.sh
+++ b/src/codenotary-cas/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/concurnas-sdkman/library_scripts.sh
+++ b/src/concurnas-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/connor-sdkman/library_scripts.sh
+++ b/src/connor-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/consul-asdf/library_scripts.sh
+++ b/src/consul-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/consul-exporter/library_scripts.sh
+++ b/src/consul-exporter/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cookiecutter/library_scripts.sh
+++ b/src/cookiecutter/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/copier/library_scripts.sh
+++ b/src/copier/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cosign/library_scripts.sh
+++ b/src/cosign/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/coverage-py/library_scripts.sh
+++ b/src/coverage-py/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/croc/library_scripts.sh
+++ b/src/croc/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/crystal-asdf/library_scripts.sh
+++ b/src/crystal-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cuba-sdkman/library_scripts.sh
+++ b/src/cuba-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cue-asdf/library_scripts.sh
+++ b/src/cue-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/curl-apt-get/library_scripts.sh
+++ b/src/curl-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/curl-homebrew/library_scripts.sh
+++ b/src/curl-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cve-bin-tool/library_scripts.sh
+++ b/src/cve-bin-tool/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cxf-sdkman/library_scripts.sh
+++ b/src/cxf-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cyclonedx-cli/library_scripts.sh
+++ b/src/cyclonedx-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cyclonedx-python/library_scripts.sh
+++ b/src/cyclonedx-python/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/cz-cli/library_scripts.sh
+++ b/src/cz-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/dasel-asdf/library_scripts.sh
+++ b/src/dasel-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/dashlane-cli/library_scripts.sh
+++ b/src/dashlane-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/datadog-ci-cli/library_scripts.sh
+++ b/src/datadog-ci-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/datasette/library_scripts.sh
+++ b/src/datasette/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ddgr-apt-get/library_scripts.sh
+++ b/src/ddgr-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ddgr-homebrew/library_scripts.sh
+++ b/src/ddgr-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/deno-asdf/library_scripts.sh
+++ b/src/deno-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/direnv-asdf/library_scripts.sh
+++ b/src/direnv-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/dive/library_scripts.sh
+++ b/src/dive/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/dnote/library_scripts.sh
+++ b/src/dnote/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/doctoolchain-sdkman/library_scripts.sh
+++ b/src/doctoolchain-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/dprint-asdf/library_scripts.sh
+++ b/src/dprint-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/driftctl/library_scripts.sh
+++ b/src/driftctl/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/drone-cli/library_scripts.sh
+++ b/src/drone-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/dua/library_scripts.sh
+++ b/src/dua/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/duf/library_scripts.sh
+++ b/src/duf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/dufs/library_scripts.sh
+++ b/src/dufs/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/eas-cli/library_scripts.sh
+++ b/src/eas-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/edge-impulse-cli/library_scripts.sh
+++ b/src/edge-impulse-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/eget/library_scripts.sh
+++ b/src/eget/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/elasticsearch-asdf/library_scripts.sh
+++ b/src/elasticsearch-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/elixir-asdf/library_scripts.sh
+++ b/src/elixir-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/elm-asdf/library_scripts.sh
+++ b/src/elm-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ember-cli/library_scripts.sh
+++ b/src/ember-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/envoy/library_scripts.sh
+++ b/src/envoy/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/erlang-asdf/library_scripts.sh
+++ b/src/erlang-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/etcd/library_scripts.sh
+++ b/src/etcd/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/exa/library_scripts.sh
+++ b/src/exa/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/exercism-cli/library_scripts.sh
+++ b/src/exercism-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/expo-cli/library_scripts.sh
+++ b/src/expo-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/express-generator/library_scripts.sh
+++ b/src/express-generator/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/fd/library_scripts.sh
+++ b/src/fd/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ffmpeg-apt-get/library_scripts.sh
+++ b/src/ffmpeg-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ffmpeg-homebrew/library_scripts.sh
+++ b/src/ffmpeg-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/firebase-cli/library_scripts.sh
+++ b/src/firebase-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/fish-apt-get/library_scripts.sh
+++ b/src/fish-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/fkill/library_scripts.sh
+++ b/src/fkill/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/flake8/library_scripts.sh
+++ b/src/flake8/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/flink-sdkman/library_scripts.sh
+++ b/src/flink-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/flit/library_scripts.sh
+++ b/src/flit/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/former2-cli/library_scripts.sh
+++ b/src/former2-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/fossil-apt-get/library_scripts.sh
+++ b/src/fossil-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/fossil-homebrew/library_scripts.sh
+++ b/src/fossil-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/fulcio/library_scripts.sh
+++ b/src/fulcio/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/fzf/library_scripts.sh
+++ b/src/fzf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gaiden-sdkman/library_scripts.sh
+++ b/src/gaiden-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ganache/library_scripts.sh
+++ b/src/ganache/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gdbgui/library_scripts.sh
+++ b/src/gdbgui/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gh-cli/library_scripts.sh
+++ b/src/gh-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gh-release/library_scripts.sh
+++ b/src/gh-release/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/git-lfs/library_scripts.sh
+++ b/src/git-lfs/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gitmux/library_scripts.sh
+++ b/src/gitmux/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gitomatic/library_scripts.sh
+++ b/src/gitomatic/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gitsign-credential-cache/library_scripts.sh
+++ b/src/gitsign-credential-cache/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gitsign/library_scripts.sh
+++ b/src/gitsign/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gitty/library_scripts.sh
+++ b/src/gitty/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/glances/library_scripts.sh
+++ b/src/glances/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/go-task/library_scripts.sh
+++ b/src/go-task/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/graalvm-asdf/library_scripts.sh
+++ b/src/graalvm-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gradle-sdkman/library_scripts.sh
+++ b/src/gradle-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gradleprofiler-sdkman/library_scripts.sh
+++ b/src/gradleprofiler-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/grails-sdkman/library_scripts.sh
+++ b/src/grails-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/graphite-exporter/library_scripts.sh
+++ b/src/graphite-exporter/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/groovy-sdkman/library_scripts.sh
+++ b/src/groovy-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/groovyserv-sdkman/library_scripts.sh
+++ b/src/groovyserv-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/grpcurl-asdf/library_scripts.sh
+++ b/src/grpcurl-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/grype/library_scripts.sh
+++ b/src/grype/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/gulp-cli/library_scripts.sh
+++ b/src/gulp-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/hadoop-sdkman/library_scripts.sh
+++ b/src/hadoop-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/hatch/library_scripts.sh
+++ b/src/hatch/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/haxe-asdf/library_scripts.sh
+++ b/src/haxe-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/homebrew-package/library_scripts.sh
+++ b/src/homebrew-package/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/hotel/library_scripts.sh
+++ b/src/hotel/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/how2/library_scripts.sh
+++ b/src/how2/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/http-server/library_scripts.sh
+++ b/src/http-server/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/http4k-sdkman/library_scripts.sh
+++ b/src/http4k-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/hyperfine/library_scripts.sh
+++ b/src/hyperfine/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/immuadmin-fips/library_scripts.sh
+++ b/src/immuadmin-fips/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/immuadmin/library_scripts.sh
+++ b/src/immuadmin/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/immuclient-fips/library_scripts.sh
+++ b/src/immuclient-fips/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/immuclient/library_scripts.sh
+++ b/src/immuclient/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/immudb-fips/library_scripts.sh
+++ b/src/immudb-fips/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/immudb/library_scripts.sh
+++ b/src/immudb/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/infracost/library_scripts.sh
+++ b/src/infracost/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/infrastructor-sdkman/library_scripts.sh
+++ b/src/infrastructor-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/invoke/library_scripts.sh
+++ b/src/invoke/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ionic-cli/library_scripts.sh
+++ b/src/ionic-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/isort/library_scripts.sh
+++ b/src/isort/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/istioctl/library_scripts.sh
+++ b/src/istioctl/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jake/library_scripts.sh
+++ b/src/jake/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jbake-sdkman/library_scripts.sh
+++ b/src/jbake-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jbang-sdkman/library_scripts.sh
+++ b/src/jbang-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jenkinsx-cli/library_scripts.sh
+++ b/src/jenkinsx-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jest/library_scripts.sh
+++ b/src/jest/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jfrog-cli-homebrew/library_scripts.sh
+++ b/src/jfrog-cli-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jfrog-cli-npm/library_scripts.sh
+++ b/src/jfrog-cli-npm/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jfrog-cli/library_scripts.sh
+++ b/src/jfrog-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jira-cli/library_scripts.sh
+++ b/src/jira-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jmc-sdkman/library_scripts.sh
+++ b/src/jmc-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jmeter-sdkman/library_scripts.sh
+++ b/src/jmeter-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/joern-sdkman/library_scripts.sh
+++ b/src/joern-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jreleaser-sdkman/library_scripts.sh
+++ b/src/jreleaser-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jrnl/library_scripts.sh
+++ b/src/jrnl/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jshint/library_scripts.sh
+++ b/src/jshint/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jsii-diff/library_scripts.sh
+++ b/src/jsii-diff/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jsii-pacmak/library_scripts.sh
+++ b/src/jsii-pacmak/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jsii-rosetta/library_scripts.sh
+++ b/src/jsii-rosetta/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/jsii/library_scripts.sh
+++ b/src/jsii/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/json-server/library_scripts.sh
+++ b/src/json-server/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/k2tf/library_scripts.sh
+++ b/src/k2tf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/k6/library_scripts.sh
+++ b/src/k6/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/karaf-sdkman/library_scripts.sh
+++ b/src/karaf-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/keepercommander/library_scripts.sh
+++ b/src/keepercommander/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ki-sdkman/library_scripts.sh
+++ b/src/ki-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/kind/library_scripts.sh
+++ b/src/kind/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ko/library_scripts.sh
+++ b/src/ko/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/kobweb-sdkman/library_scripts.sh
+++ b/src/kobweb-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/kops/library_scripts.sh
+++ b/src/kops/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/kotlin-sdkman/library_scripts.sh
+++ b/src/kotlin-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/kscript-sdkman/library_scripts.sh
+++ b/src/kscript-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/kubeclarity-cli/library_scripts.sh
+++ b/src/kubeclarity-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/kubectl-asdf/library_scripts.sh
+++ b/src/kubectl-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/kubescape/library_scripts.sh
+++ b/src/kubescape/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/kyverno-cli/library_scripts.sh
+++ b/src/kyverno-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/lastpass-cli-homebrew/library_scripts.sh
+++ b/src/lastpass-cli-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/layrry-sdkman/library_scripts.sh
+++ b/src/layrry-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/lean-asdf/library_scripts.sh
+++ b/src/lean-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/leiningen-sdkman/library_scripts.sh
+++ b/src/leiningen-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/lektor/library_scripts.sh
+++ b/src/lektor/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/lerna-npm/library_scripts.sh
+++ b/src/lerna-npm/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/less/library_scripts.sh
+++ b/src/less/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/levant-asdf/library_scripts.sh
+++ b/src/levant-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/lighthouse-cli/library_scripts.sh
+++ b/src/lighthouse-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/linkerd2-cli-edge/library_scripts.sh
+++ b/src/linkerd2-cli-edge/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/linkerd2-cli-stable/library_scripts.sh
+++ b/src/linkerd2-cli-stable/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/linode-cli/library_scripts.sh
+++ b/src/linode-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/lite-server/library_scripts.sh
+++ b/src/lite-server/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/live-server/library_scripts.sh
+++ b/src/live-server/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/localstack/library_scripts.sh
+++ b/src/localstack/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/localtunnel-npm/library_scripts.sh
+++ b/src/localtunnel-npm/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mackup/library_scripts.sh
+++ b/src/mackup/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mage/library_scripts.sh
+++ b/src/mage/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/markdownlint-cli/library_scripts.sh
+++ b/src/markdownlint-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/markdownlint-cli2/library_scripts.sh
+++ b/src/markdownlint-cli2/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/maven-sdkman/library_scripts.sh
+++ b/src/maven-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/meltano/library_scripts.sh
+++ b/src/meltano/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/memcached-exporter/library_scripts.sh
+++ b/src/memcached-exporter/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/meson-asdf/library_scripts.sh
+++ b/src/meson-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/meteor-cli/library_scripts.sh
+++ b/src/meteor-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/micro/library_scripts.sh
+++ b/src/micro/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/micronaut-sdkman/library_scripts.sh
+++ b/src/micronaut-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mitmproxy/library_scripts.sh
+++ b/src/mitmproxy/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mkcert/library_scripts.sh
+++ b/src/mkcert/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mkdocs/library_scripts.sh
+++ b/src/mkdocs/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mlocate-apt-get/library_scripts.sh
+++ b/src/mlocate-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mlton-asdf/library_scripts.sh
+++ b/src/mlton-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mocha/library_scripts.sh
+++ b/src/mocha/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mongodb-atlas-cli-homebrew/library_scripts.sh
+++ b/src/mongodb-atlas-cli-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mongosh-homebrew/library_scripts.sh
+++ b/src/mongosh-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mosh-apt-get/library_scripts.sh
+++ b/src/mosh-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mosh-homebrew/library_scripts.sh
+++ b/src/mosh-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mulefd-sdkman/library_scripts.sh
+++ b/src/mulefd-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mvnd-sdkman/library_scripts.sh
+++ b/src/mvnd-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mybatis-sdkman/library_scripts.sh
+++ b/src/mybatis-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mypy/library_scripts.sh
+++ b/src/mypy/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mysql-homebrew/library_scripts.sh
+++ b/src/mysql-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/mysqld-exporter/library_scripts.sh
+++ b/src/mysqld-exporter/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/n8n/library_scripts.sh
+++ b/src/n8n/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nancy/library_scripts.sh
+++ b/src/nancy/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/navi/library_scripts.sh
+++ b/src/navi/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ncdu/library_scripts.sh
+++ b/src/ncdu/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/neko-asdf/library_scripts.sh
+++ b/src/neko-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/neo4jmigrations-sdkman/library_scripts.sh
+++ b/src/neo4jmigrations-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/neofetch/library_scripts.sh
+++ b/src/neofetch/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/neovim-apt-get/library_scripts.sh
+++ b/src/neovim-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/neovim-homebrew/library_scripts.sh
+++ b/src/neovim-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nestjs-cli/library_scripts.sh
+++ b/src/nestjs-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/netdata/library_scripts.sh
+++ b/src/netdata/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/netlify-cli/library_scripts.sh
+++ b/src/netlify-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nim-asdf/library_scripts.sh
+++ b/src/nim-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ninja-asdf/library_scripts.sh
+++ b/src/ninja-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nmap-apt-get/library_scripts.sh
+++ b/src/nmap-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nmap-homebrew/library_scripts.sh
+++ b/src/nmap-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nnn-apt-get/library_scripts.sh
+++ b/src/nnn-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nnn-homebrew/library_scripts.sh
+++ b/src/nnn-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/node-exporter/library_scripts.sh
+++ b/src/node-exporter/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nomad-asdf/library_scripts.sh
+++ b/src/nomad-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nox/library_scripts.sh
+++ b/src/nox/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nushell/library_scripts.sh
+++ b/src/nushell/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/nx-npm/library_scripts.sh
+++ b/src/nx-npm/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ocaml-asdf/library_scripts.sh
+++ b/src/ocaml-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/oclif/library_scripts.sh
+++ b/src/oclif/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/opa/library_scripts.sh
+++ b/src/opa/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/opam-asdf/library_scripts.sh
+++ b/src/opam-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ory-cli/library_scripts.sh
+++ b/src/ory-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ory-hydra/library_scripts.sh
+++ b/src/ory-hydra/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ory-keto/library_scripts.sh
+++ b/src/ory-keto/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ory-kratos/library_scripts.sh
+++ b/src/ory-kratos/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ory-oathkeeper/library_scripts.sh
+++ b/src/ory-oathkeeper/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/packer-asdf/library_scripts.sh
+++ b/src/packer-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pandoc/library_scripts.sh
+++ b/src/pandoc/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pass-apt-get/library_scripts.sh
+++ b/src/pass-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pdm/library_scripts.sh
+++ b/src/pdm/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/peco-asdf/library_scripts.sh
+++ b/src/peco-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/perl-asdf/library_scripts.sh
+++ b/src/perl-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pierrot-sdkman/library_scripts.sh
+++ b/src/pierrot-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pip-audit/library_scripts.sh
+++ b/src/pip-audit/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pipenv/library_scripts.sh
+++ b/src/pipenv/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pnpm/library_scripts.sh
+++ b/src/pnpm/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/podman-homebrew/library_scripts.sh
+++ b/src/podman-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/poetry/library_scripts.sh
+++ b/src/poetry/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pomchecker-sdkman/library_scripts.sh
+++ b/src/pomchecker-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/porter/library_scripts.sh
+++ b/src/porter/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/postgres-asdf/library_scripts.sh
+++ b/src/postgres-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/powerbi-visuals-tools/library_scripts.sh
+++ b/src/powerbi-visuals-tools/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/powershell/library_scripts.sh
+++ b/src/powershell/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pre-commit/library_scripts.sh
+++ b/src/pre-commit/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/prettier/library_scripts.sh
+++ b/src/prettier/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/prisma/library_scripts.sh
+++ b/src/prisma/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/projen/library_scripts.sh
+++ b/src/projen/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/prometheus/library_scripts.sh
+++ b/src/prometheus/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/promlens/library_scripts.sh
+++ b/src/promlens/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/protoc-asdf/library_scripts.sh
+++ b/src/protoc-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/protoc/library_scripts.sh
+++ b/src/protoc/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pushgateway/library_scripts.sh
+++ b/src/pushgateway/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pyinfra/library_scripts.sh
+++ b/src/pyinfra/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pylint/library_scripts.sh
+++ b/src/pylint/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pyoxidizer/library_scripts.sh
+++ b/src/pyoxidizer/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/pyscaffold/library_scripts.sh
+++ b/src/pyscaffold/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/qrcode/library_scripts.sh
+++ b/src/qrcode/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/quarkus-sdkman/library_scripts.sh
+++ b/src/quarkus-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/quasar-cli/library_scripts.sh
+++ b/src/quasar-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/rabbitmq-asdf/library_scripts.sh
+++ b/src/rabbitmq-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/raku-asdf/library_scripts.sh
+++ b/src/raku-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/rclone/library_scripts.sh
+++ b/src/rclone/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/redis-homebrew/library_scripts.sh
+++ b/src/redis-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/rekor-cli/library_scripts.sh
+++ b/src/rekor-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/renovate-cli/library_scripts.sh
+++ b/src/renovate-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/ripgrep/library_scripts.sh
+++ b/src/ripgrep/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/rollup/library_scripts.sh
+++ b/src/rollup/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/salesforce-cli/library_scripts.sh
+++ b/src/salesforce-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/salesforce-sfdx/library_scripts.sh
+++ b/src/salesforce-sfdx/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/sanity-cli/library_scripts.sh
+++ b/src/sanity-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/sap-piper/library_scripts.sh
+++ b/src/sap-piper/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/sbt-sdkman/library_scripts.sh
+++ b/src/sbt-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/scala-asdf/library_scripts.sh
+++ b/src/scala-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/scala-sdkman/library_scripts.sh
+++ b/src/scala-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/scalacli-sdkman/library_scripts.sh
+++ b/src/scalacli-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/scancode-toolkit/library_scripts.sh
+++ b/src/scancode-toolkit/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/schemacrawler-sdkman/library_scripts.sh
+++ b/src/schemacrawler-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/sentinel-asdf/library_scripts.sh
+++ b/src/sentinel-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/serf-asdf/library_scripts.sh
+++ b/src/serf-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/serverless/library_scripts.sh
+++ b/src/serverless/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/shopify-cli/library_scripts.sh
+++ b/src/shopify-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/sigstore-python/library_scripts.sh
+++ b/src/sigstore-python/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/snyk-cli/library_scripts.sh
+++ b/src/snyk-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/sops/library_scripts.sh
+++ b/src/sops/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/spacectl/library_scripts.sh
+++ b/src/spacectl/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/spark-sdkman/library_scripts.sh
+++ b/src/spark-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/spicedb/library_scripts.sh
+++ b/src/spicedb/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/springboot-sdkman/library_scripts.sh
+++ b/src/springboot-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/squarespace-server/library_scripts.sh
+++ b/src/squarespace-server/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/sshoogr-sdkman/library_scripts.sh
+++ b/src/sshoogr-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/starship-homebrew/library_scripts.sh
+++ b/src/starship-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/starship/library_scripts.sh
+++ b/src/starship/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/statsd-exporter/library_scripts.sh
+++ b/src/statsd-exporter/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/stew/library_scripts.sh
+++ b/src/stew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/supabase-cli/library_scripts.sh
+++ b/src/supabase-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/surge-cli/library_scripts.sh
+++ b/src/surge-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/sv2v/library_scripts.sh
+++ b/src/sv2v/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/svu-asdf/library_scripts.sh
+++ b/src/svu-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/syft/library_scripts.sh
+++ b/src/syft/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/syncthing/library_scripts.sh
+++ b/src/syncthing/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/syntaqx-serve/library_scripts.sh
+++ b/src/syntaqx-serve/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tailscale/library_scripts.sh
+++ b/src/tailscale/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/taxi-sdkman/library_scripts.sh
+++ b/src/taxi-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tea/library_scripts.sh
+++ b/src/tea/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tekton-cli/library_scripts.sh
+++ b/src/tekton-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tempo/library_scripts.sh
+++ b/src/tempo/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/temporal-cli/library_scripts.sh
+++ b/src/temporal-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/terracognita/library_scripts.sh
+++ b/src/terracognita/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/terraform-asdf/library_scripts.sh
+++ b/src/terraform-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/terraform-docs/library_scripts.sh
+++ b/src/terraform-docs/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/terraform-ls-asdf/library_scripts.sh
+++ b/src/terraform-ls-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/terraformer/library_scripts.sh
+++ b/src/terraformer/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/terragrunt/library_scripts.sh
+++ b/src/terragrunt/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/terramate/library_scripts.sh
+++ b/src/terramate/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tfc-agent-asdf/library_scripts.sh
+++ b/src/tfc-agent-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tfcdk-cli/library_scripts.sh
+++ b/src/tfcdk-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tfenv-homebrew/library_scripts.sh
+++ b/src/tfenv-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tfsec/library_scripts.sh
+++ b/src/tfsec/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tfswitch/library_scripts.sh
+++ b/src/tfswitch/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tldr/library_scripts.sh
+++ b/src/tldr/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tmate/library_scripts.sh
+++ b/src/tmate/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tmux-apt-get/library_scripts.sh
+++ b/src/tmux-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tmux-homebrew/library_scripts.sh
+++ b/src/tmux-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tomcat-sdkman/library_scripts.sh
+++ b/src/tomcat-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tooljet-cli/library_scripts.sh
+++ b/src/tooljet-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/toolkit-sdkman/library_scripts.sh
+++ b/src/toolkit-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tox/library_scripts.sh
+++ b/src/tox/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/trello-cli/library_scripts.sh
+++ b/src/trello-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/tridentctl-asdf/library_scripts.sh
+++ b/src/tridentctl-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/trivy/library_scripts.sh
+++ b/src/trivy/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/truffle/library_scripts.sh
+++ b/src/truffle/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/turborepo-npm/library_scripts.sh
+++ b/src/turborepo-npm/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/twine/library_scripts.sh
+++ b/src/twine/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/typescript/library_scripts.sh
+++ b/src/typescript/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/typst/library_scripts.sh
+++ b/src/typst/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/upx/library_scripts.sh
+++ b/src/upx/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vault-asdf/library_scripts.sh
+++ b/src/vault-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vercel-cli/library_scripts.sh
+++ b/src/vercel-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vercel-ncc/library_scripts.sh
+++ b/src/vercel-ncc/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vercel-pkg/library_scripts.sh
+++ b/src/vercel-pkg/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vercel-release/library_scripts.sh
+++ b/src/vercel-release/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vercel-serve/library_scripts.sh
+++ b/src/vercel-serve/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vertx-sdkman/library_scripts.sh
+++ b/src/vertx-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/visualvm-sdkman/library_scripts.sh
+++ b/src/visualvm-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/volta/library_scripts.sh
+++ b/src/volta/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vtop/library_scripts.sh
+++ b/src/vtop/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vue-cli/library_scripts.sh
+++ b/src/vue-cli/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/vulture/library_scripts.sh
+++ b/src/vulture/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/w3m-apt-get/library_scripts.sh
+++ b/src/w3m-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/w3m-homebrew/library_scripts.sh
+++ b/src/w3m-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/waypoint-asdf/library_scripts.sh
+++ b/src/waypoint-asdf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/webtau-sdkman/library_scripts.sh
+++ b/src/webtau-sdkman/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/wget-apt-get/library_scripts.sh
+++ b/src/wget-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/wget-homebrew/library_scripts.sh
+++ b/src/wget-homebrew/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/wireguard-apt-get/library_scripts.sh
+++ b/src/wireguard-apt-get/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/xmrig/library_scripts.sh
+++ b/src/xmrig/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/xonsh/library_scripts.sh
+++ b/src/xonsh/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/xplr/library_scripts.sh
+++ b/src/xplr/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/yamllint/library_scripts.sh
+++ b/src/yamllint/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/yapf/library_scripts.sh
+++ b/src/yapf/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/youtube-dl/library_scripts.sh
+++ b/src/youtube-dl/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/youtubeuploader/library_scripts.sh
+++ b/src/youtubeuploader/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version

--- a/src/yt-dlp/library_scripts.sh
+++ b/src/yt-dlp/library_scripts.sh
@@ -116,7 +116,7 @@ ensure_nanolayer() {
             fi
         elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
             nanolayer_location=${NANOLAYER_CLI_LOCATION}
-            echo "Found a pre-existing nanolayer which were given in env varialbe: $nanolayer_location"
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
         fi
 
         # make sure its of the required version


### PR DESCRIPTION
Hello! I just noticed a small typo in `library_scripts.sh` where you print out "Found a pre-existing nanolayer which were given in env varialbe". I updated it from "varialbe" to "variable". 