### PR TITLE
Allow api-ops arm version install

### DIFF
--- a/src/azure-apiops/install.sh
+++ b/src/azure-apiops/install.sh
@@ -10,12 +10,23 @@ set -e
 # of the script
 ensure_nanolayer nanolayer_location "v0.5.3"
 
+architecture="$(uname -m)"
+case ${architecture} in
+x86_64) architecture="linux-x64" ;;
+aarch64 | armv8*) architecture="linux-arm64" ;;
+*)
+	echo "(!) Architecture ${architecture} unsupported"
+	exit 1
+	;;
+esac
+
+echo "Architecture: ${architecture}"
 
 $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-contrib/features/gh-release:1.0.21" \
-    --option repo='Azure/apiops' --option binaryNames='extractor' --option assetRegex='^extractor.linux-x64.exe' --option version="$VERSION"
+    --option repo='Azure/apiops' --option binaryNames='extractor' --option assetRegex="^extractor.${architecture}.exe" --option version="$VERSION"
     
 
 
@@ -23,9 +34,8 @@ $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-contrib/features/gh-release:1.0.21" \
-    --option repo='Azure/apiops' --option binaryNames='publisher' --option assetRegex='^publisher.linux-x64.exe' --option version="$VERSION"
+    --option repo='Azure/apiops' --option binaryNames='publisher' --option assetRegex="^publisher.${architecture}.exe" --option version="$VERSION"
     
-
 
 echo 'Done!'
 


### PR DESCRIPTION
- Determine the architecture that is running and decide on whether to install the Apple M1/M2 version or Intel.