### PR TITLE
fix: install script failing silently on inner non-root script erroring

### DIFF
--- a/src/pulumi/install.sh
+++ b/src/pulumi/install.sh
@@ -32,6 +32,8 @@ check_packages ca-certificates curl
 # substituted inside the $_REMOTE_USER shell. Particularily $HOME which needs to
 # be from the $_REMOTE_USER, and $VERSION which needs to come from this script.
 sudo -iu "$_REMOTE_USER" <<EOF
+    set -eo pipefail
+
     # making sure shell configs are there, as pulumi installation script rely on
     # their existance in order to add its binary to the user's PATH
     if [ ! -f "\${HOME}/.bashrc" ] || [ ! -s "\${HOME}/.bashrc" ] ; then


### PR DESCRIPTION
Currently if any command fails within the non-root user script block the installation will fail silently resulting in `pulumi` not being present in the devcontainer image.

I stumbled into this issue when `get.pulumi.com` was caught by company firewall's SSL filtering, but it was not obvious so I had to dig into what exactly was silently failing.

```
#15 [dev_containers_target_stage 5/6] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=pulumi_0,target=/tmp/build-features-src/pulumi_0     cp -ar /tmp/build-features-src/pulumi_0 /tmp/dev-container-features  && chmod -R 0755 /tmp/dev-container-features/pulumi_0  && cd /tmp/dev-container-features/pulumi_0  && chmod +x ./devcontainer-features-install.sh  && ./devcontainer-features-install.sh  && rm -rf /tmp/dev-container-features/pulumi_0
#15 0.532 ===========================================================================
#15 0.532 Feature       : Pulumi (via get.pulumi.com)
#15 0.532 Description   : Pulumi is a modern infrastructure as code platform
#15 0.532 Id            : ghcr.io/devcontainers-contrib/features/pulumi
#15 0.532 Version       : 1.2.3
#15 0.532 Documentation : https://github.com/devcontainers-contrib/features/tree/main/src/pulumi
#15 0.532 Options       :
#15 0.532     VERSION="latest"
#15 0.532     BASHCOMPLETION="true"
#15 0.532 ===========================================================================
#15 0.611 curl: (60) SSL certificate problem: unable to get local issuer certificate
#15 0.611 More details here: https://curl.se/docs/sslcerts.html
#15 0.611 
#15 0.611 curl failed to verify the legitimacy of the server and therefore could not
#15 0.611 establish a secure connection to it. To learn more about this situation and
#15 0.611 how to fix it, please visit the web page mentioned above.
#15 0.620 /bin/bash: line 9: pulumi: command not found
#15 0.629 Done!
#15 DONE 0.6s
```
