### PR TITLE
Extend the sqlfluff feature to support the injection of sqlfluff plugins

### DIFF
--- a/src/sqlfluff/README.md
+++ b/src/sqlfluff/README.md
@@ -16,5 +16,5 @@ Fluff is an extensible and modular linter designed to help you write good SQL an
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | version | Select the version to install. | string | latest |
-
+| plugins | A space delimitered list of sqlfluff plugins (will be injected into the sqlfluff pipx env). See proposals for examples. | string | - |
 

--- a/src/sqlfluff/devcontainer-feature.json
+++ b/src/sqlfluff/devcontainer-feature.json
@@ -12,6 +12,15 @@
                 "latest"
             ],
             "type": "string"
+        },
+        "plugins": {
+            "default": "",
+            "description": "A space delimitered list of sqlfluff plugins (will be injected into the sqlfluff pipx env). See proposals for examples.",
+            "proposals": [
+                "sqlfluff-templater-dbt==2.3.5",
+                "sqlfluff-templater-dbt sqlfluff-plugin-sparksql-upgrade"
+            ],
+            "type": "string"
         }
     },
     "installsAfter": [

--- a/src/sqlfluff/install.sh
+++ b/src/sqlfluff/install.sh
@@ -5,8 +5,8 @@ set -e
 
 # nanolayer is a cli utility which keeps container layers as small as possible
 # source code: https://github.com/devcontainers-contrib/nanolayer
-# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations, 
-# and if missing - will download a temporary copy that automatically get deleted at the end 
+# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations,
+# and if missing - will download a temporary copy that automatically get deleted at the end
 # of the script
 ensure_nanolayer nanolayer_location "v0.5.0"
 
@@ -15,8 +15,8 @@ $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
-    --option package='sqlfluff' --option version="$VERSION"
-    
+    --option package='sqlfluff' --option version="$VERSION" --option injections="$PLUGINS"
+
 
 
 echo 'Done!'


### PR DESCRIPTION
## Problem
I'm are using the `sqlfluff` linter in a [dbt](https://www.getdbt.com/) project. Support for `dbt` in `sqlfluff` is added via the [sqlfluff-templater-dbt](https://pypi.org/project/sqlfluff-templater-dbt/) plugin which needs to be installed alongside `sqlfluff`.

## Solution
Extend the `sqlfluff` feature to support an optional `plugins` option that can pass a space separated list of plugins to be installed.

Example:
```json
{
  "features": {
    "ghcr.io/devcontainers-contrib/features/sqlfluff:1": {
      "version": "latest",
      "plugins": "sqlfluff-templater-dbt==2.3.5"
    }
  }
}
```

## Notes
First time contributing to this project - feel free to let me know if there's anything else I need/should add