### PR TITLE
Add Bun Installation Features via GitHub Releases and asdf Version Manager

### DIFF
--- a/src/bun-asdf/README.md
+++ b/src/bun-asdf/README.md
@@ -1,0 +1,18 @@
+
+# Bun Installation Feature for DevContainer
+
+This feature provides a robust way to install and manage Bun, a fast all-in-one JavaScript runtime, using the `asdf` version manager. This allows you to specify and switch between different versions of Bun easily.
+
+## Example DevContainer Usage
+
+```json
+"features": {
+    "ghcr.io/devcontainers-contrib/features/bun-asdf:2": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Select the version to install. | string | latest |

--- a/src/bun-asdf/devcontainer-feature.json
+++ b/src/bun-asdf/devcontainer-feature.json
@@ -1,0 +1,20 @@
+{
+    "id": "bun-asdf",
+    "version": "1.0.0",
+    "name": "Bun (via asdf)",
+    "description": "Bun is a fast all-in-one JavaScript runtime that uses the asdf version manager for installation.",
+    "documentationURL": "http://github.com/devcontainers-contrib/features/tree/main/src/bun-asdf",
+    "options": {
+        "version": {
+            "default": "latest",
+            "description": "Select the Bun version to install.",
+            "proposals": [
+                "latest"
+            ],
+            "type": "string"
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers-contrib/features/asdf-package"
+    ]
+}

--- a/src/bun-asdf/install.sh
+++ b/src/bun-asdf/install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -i
+
+set -e
+
+source ./library_scripts.sh
+
+# nanolayer is a cli utility which keeps container layers as small as possible
+# source code: https://github.com/devcontainers-contrib/nanolayer
+# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations, 
+# and if missing - will download a temporary copy that automatically get deleted at the end 
+# of the script
+ensure_nanolayer nanolayer_location "v0.4.45"
+
+# Install Bun using asdf
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-contrib/features/asdf-package:1.0.8" \
+    --option plugin='bun' --option version="$VERSION"
+
+echo 'Bun installation complete!'

--- a/src/bun-asdf/library_scripts.sh
+++ b/src/bun-asdf/library_scripts.sh
@@ -1,0 +1,179 @@
+#!/bin/bash -i
+
+
+clean_download() {
+    # The purpose of this function is to download a file with minimal impact on container layer size
+    # this means if no valid downloader is found (curl or wget) then we install a downloader (currently wget) in a 
+    # temporary manner, and making sure to 
+    # 1. uninstall the downloader at the return of the function
+    # 2. revert back any changes to the package installer database/cache (for example apt-get lists)
+    # The above steps will minimize the leftovers being created while installing the downloader 
+    # Supported distros:
+    #  debian/ubuntu/alpine
+    
+    url=$1
+    output_location=$2
+    tempdir=$(mktemp -d)
+    downloader_installed=""
+
+    function _apt_get_install() {
+        tempdir=$1
+
+        # copy current state of apt list - in order to revert back later (minimize contianer layer size) 
+        cp -p -R /var/lib/apt/lists $tempdir 
+        apt-get update -y
+        apt-get -y install --no-install-recommends wget ca-certificates
+    }
+
+    function _apt_get_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apt-get -y purge wget --auto-remove
+
+        echo "revert back apt lists"
+        rm -rf /var/lib/apt/lists/*
+        rm -r /var/lib/apt/lists && mv $tempdir/lists /var/lib/apt/lists
+    }
+
+    function _apk_install() {
+        tempdir=$1
+        # copy current state of apk cache - in order to revert back later (minimize contianer layer size) 
+        cp -p -R /var/cache/apk $tempdir 
+
+        apk add --no-cache  wget
+    }
+
+    function _apk_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apk del wget 
+    }
+    # try to use either wget or curl if one of them already installer
+    if type curl >/dev/null 2>&1; then
+        downloader=curl
+    elif type wget >/dev/null 2>&1; then
+        downloader=wget
+    else
+        downloader=""
+    fi
+
+    # in case none of them is installed, install wget temporarly
+    if [ -z $downloader ] ; then
+        if [ -x "/usr/bin/apt-get" ] ; then
+            _apt_get_install $tempdir
+        elif [ -x "/sbin/apk" ] ; then
+            _apk_install $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+        downloader="wget"
+        downloader_installed="true"
+    fi
+
+    if [ $downloader = "wget" ] ; then
+        wget -q $url -O $output_location
+    else
+        curl -sfL $url -o $output_location 
+    fi
+
+    # NOTE: the cleanup procedure was not implemented using `trap X RETURN` only because
+    # alpine lack bash, and RETURN is not a valid signal under sh shell
+    if ! [ -z $downloader_installed  ] ; then
+        if [ -x "/usr/bin/apt-get" ] ; then
+            _apt_get_cleanup $tempdir
+        elif [ -x "/sbin/apk" ] ; then
+            _apk_cleanup $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+    fi 
+
+}
+
+
+ensure_nanolayer() {
+    # Ensure existance of the nanolayer cli program
+    local variable_name=$1
+
+    local required_version=$2
+    # normalize version
+    if ! [[ $required_version == v* ]]; then
+        required_version=v$required_version
+    fi
+
+    local nanolayer_location=""
+
+    # If possible - try to use an already installed nanolayer
+    if [[ -z "${NANOLAYER_FORCE_CLI_INSTALLATION}" ]]; then
+        if [[ -z "${NANOLAYER_CLI_LOCATION}" ]]; then
+            if type nanolayer >/dev/null 2>&1; then
+                echo "Found a pre-existing nanolayer in PATH"
+                nanolayer_location=nanolayer
+            fi
+        elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
+            nanolayer_location=${NANOLAYER_CLI_LOCATION}
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
+        fi
+
+        # make sure its of the required version
+        if ! [[ -z "${nanolayer_location}" ]]; then
+            local current_version
+            current_version=$($nanolayer_location --version)
+            if ! [[ $current_version == v* ]]; then
+                current_version=v$current_version
+            fi
+
+            if ! [ $current_version == $required_version ]; then
+                echo "skipping usage of pre-existing nanolayer. (required version $required_version does not match existing version $current_version)"
+                nanolayer_location=""
+            fi
+        fi
+
+    fi
+
+    # If not previuse installation found, download it temporarly and delete at the end of the script 
+    if [[ -z "${nanolayer_location}" ]]; then
+
+        if [ "$(uname -sm)" == "Linux x86_64" ] || [ "$(uname -sm)" == "Linux aarch64" ]; then
+            tmp_dir=$(mktemp -d -t nanolayer-XXXXXXXXXX)
+
+            clean_up () {
+                ARG=$?
+                rm -rf $tmp_dir
+                exit $ARG
+            }
+            trap clean_up EXIT
+
+            
+            if [ -x "/sbin/apk" ] ; then
+                clib_type=musl
+            else
+                clib_type=gnu
+            fi
+
+            tar_filename=nanolayer-"$(uname -m)"-unknown-linux-$clib_type.tgz
+
+            # clean download will minimize leftover in case a downloaderlike wget or curl need to be installed
+            clean_download https://github.com/devcontainers-contrib/cli/releases/download/$required_version/$tar_filename $tmp_dir/$tar_filename
+            
+            tar xfzv $tmp_dir/$tar_filename -C "$tmp_dir"
+            chmod a+x $tmp_dir/nanolayer
+            nanolayer_location=$tmp_dir/nanolayer
+      
+
+        else
+            echo "No binaries compiled for non-x86-linux architectures yet: $(uname -m)"
+            exit 1
+        fi
+    fi
+
+    # Expose outside the resolved location
+    declare -g ${variable_name}=$nanolayer_location
+
+}
+
+

--- a/src/bun/README.md
+++ b/src/bun/README.md
@@ -1,0 +1,17 @@
+# Bun Installation Feature for DevContainer
+
+This feature installs Bun, a fast all-in-one JavaScript runtime, using the official GitHub releases. It ensures the latest or a specific version of Bun is installed according to the platform requirements of the user's system.
+
+## Example DevContainer Usage
+
+```json
+"features": {
+    "ghcr.io/devcontainers-contrib/features/bun:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Select the version to install. | string | latest |

--- a/src/bun/devcontainer-feature.json
+++ b/src/bun/devcontainer-feature.json
@@ -1,0 +1,17 @@
+{
+    "id": "bun",
+    "version": "1.0.0",
+    "name": "Bun (via GitHub releases)",
+    "description": "Bun is a fast all-in-one JavaScript runtime installed using GitHub releases.",
+    "documentationURL": "https://github.com/devcontainers-contrib/features/tree/main/src/bun",
+    "options": {
+        "version": {
+            "type": "string",
+            "proposals": [
+                "latest"
+            ],
+            "default": "latest",
+            "description": "Select the Bun version you would like to install"
+        }
+    }
+}

--- a/src/bun/install.sh
+++ b/src/bun/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -e
+
+BUN_VERSION="${VERSION:-"latest"}"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+command -v unzip >/dev/null || { echo "unzip is required to install Bun." ; exit 1; }
+
+# Determine platform
+case $(uname -ms) in
+    "Linux x86_64")
+        PLATFORM="linux-x64"
+        ;;
+    "Linux aarch64")
+        PLATFORM="linux-aarch64"
+        ;;
+    "Darwin x86_64")
+        PLATFORM="darwin-x64"
+        ;;
+    "Darwin arm64")
+        PLATFORM="darwin-aarch64"
+        ;;
+    *)
+        echo "Unsupported platform"
+        exit 1
+        ;;
+esac
+
+# Check if AVX2 support is needed for Linux or Darwin x64
+if [[ "$PLATFORM" == "linux-x64" || "$PLATFORM" == "darwin-x64" ]]; then
+    if ! grep -q avx2 /proc/cpuinfo && [ "$(uname)" == "Linux" ]; then
+        PLATFORM="${PLATFORM}-baseline"
+    elif ! sysctl -a | grep -q avx2 && [ "$(uname)" == "Darwin" ]; then
+        PLATFORM="${PLATFORM}-baseline"
+    fi
+fi
+
+BUN_BINARY="bun-${PLATFORM}.zip"
+BUN_URL="https://github.com/oven-sh/bun/releases/download/${BUN_VERSION}/${BUN_BINARY}"
+
+# Download and install Bun
+curl -fsSL "$BUN_URL" -o /tmp/$BUN_BINARY
+unzip /tmp/$BUN_BINARY -d /usr/local/bin
+chmod +x /usr/local/bin/bun
+
+echo "Bun installation complete."
+echo "Add /usr/local/bin to your PATH to use bun from the command line."


### PR DESCRIPTION
This pull request introduces two new features for installing [Bun](https://github.com/oven-sh/bun), a fast all-in-one JavaScript runtime, in devcontainers:

1. **Bun Installation via GitHub Releases**
  - Installs Bun using the official GitHub releases.
  - Ensures the latest or a specific version of Bun is installed based on the platform requirements of the user's system.
  - Supports Linux (x86_64 and aarch64), macOS (x86_64 and arm64).

2. **Bun Installation via asdf Version Manager**
  - Installs Bun using the `asdf` version manager and the [asdf-bun](https://github.com/cometkim/asdf-bun) plugin.
  - Allows specifying and switching between different versions of Bun easily.
  - Leverages the `asdf-bun` plugin, which is already included in the official [asdf plugins repository](https://github.com/asdf-vm/asdf-plugins/blob/master/plugins/bun).

Both features provide a convenient and flexible way to incorporate Bun into your devcontainer setup. They allow you to choose between a direct installation via GitHub releases or a version-managed installation using `asdf`.

Example usage in a devcontainer configuration:

```json
"features": {
 "ghcr.io/devcontainers-contrib/features/bun:1": {},
 "ghcr.io/devcontainers-contrib/features/bun-asdf:1": {}
}