### PR TITLE
Fix the pipx-package inject command

### DIFF
--- a/src/pipx-package/install.sh
+++ b/src/pipx-package/install.sh
@@ -149,7 +149,7 @@ install_via_pipx() {
 		injections_array_length="${#injections_array[@]}"
 
 		for ((i = 0; i < ${injections_array_length}; i++)); do
-			${pipx_bin} inject "$PACKAGE" --pip-args '--no-cache-dir --force-reinstall' -f "${injections_array[$i]}"
+			${pipx_bin} inject "$PACKAGE" "${injections_array[$i]}" --pip-args '--no-cache-dir --force-reinstall' -f
 		done
 
 		# cleaning pipx to save disk space


### PR DESCRIPTION
As per #607 pipx-package errors with the following, when being used with injections:

```
pipx: error: unrecognized arguments: 
```

The reason for this behaviour is a change in pipx. The resulting backwards incompatibility is discussed here: https://github.com/pypa/pipx/issues/1444

There someone metioned the following:
> Seems there is no easy solution for back-compatibility while keeping the --requirement feature. :-(

For this reason I propose to change the order to fix the feature for the time being.

Hopefully I am not missing something important.