### PR TITLE
Add VS Code extension to the Ruff feature

### DIFF
--- a/src/ruff/devcontainer-feature.json
+++ b/src/ruff/devcontainer-feature.json
@@ -14,6 +14,13 @@
             "type": "string"
         }
     },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "charliermarsh.ruff"
+            ]
+        }
+    },
     "installsAfter": [
         "ghcr.io/devcontainers-contrib/features/pipx-package",
         "ghcr.io/devcontainers/features/python"


### PR DESCRIPTION
Automatically install the Ruff extension in VS Code when using the Ruff feature. This is what the official Python feature does with the Python extension.