### PR TITLE
fix: fix bitwarden-cli by selected oss binary

### DIFF
--- a/.github/actions/list-changed-features-action/action.yaml
+++ b/.github/actions/list-changed-features-action/action.yaml
@@ -3,7 +3,6 @@ description: "Get a json list the changed features (accounting for generator cha
 inputs:
   path:
     description: "Base feature folder (containing src and test folders)"
-    type: string
     required: true
 
 outputs:
@@ -25,21 +24,21 @@ runs:
     - run: sudo apt update && sudo apt install tree jq -y
       shell: bash
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         list-files: json
         filters: |
-          src: 
+          src:
             - src/**/*.sh
-          test: 
+          test:
             - test/**/*.sh
 
     - id: feature-finder
       shell: bash
       run: |
         echo '${{ steps.filter.outputs.changes }}'
-        
+
         # prepare all features
         all_features=$(sudo tree -J -d  ./src | sudo jq -c '.[0].contents | map(.name)')
 
@@ -52,7 +51,7 @@ runs:
         jq -sc '.[0] + .[1] | unique'  changed_src_features.json changed_test_features.json > changed_features.json
         changed_features=$(cat changed_features.json)
 
-        # outputs 
+        # outputs
         echo "all_features=$all_features" >> $GITHUB_OUTPUT
         echo "changed_features=$changed_features" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Publish Features"
         uses: devcontainers/action@v1
@@ -27,6 +27,6 @@ jobs:
           publish-features: "true"
           base-path-to-features: "./src"
           generate-docs: "false"
-          
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,11 +29,11 @@ on:
     - cron:  '0 1 * * *'
 
   pull_request:
-  
+
   push:
     branches:
       - main
-      
+
 jobs:
 
   find-features:
@@ -44,10 +44,10 @@ jobs:
       all-features: ${{ steps.list-features.outputs.all_features }}
       changed-features: ${{ steps.list-features.outputs.changed_features }}
     steps:
-      - uses: actions/checkout@v3   
+      - uses: actions/checkout@v4
       - run: |
           echo ${{ inputs.enabled  }}
-          echo ${{ github.event_name  }} 
+          echo ${{ github.event_name  }}
 
       - id: list-features
         uses: ./.github/actions/list-changed-features-action
@@ -68,7 +68,7 @@ jobs:
 
           elif [ ${{ github.event_name	}} == 'push' ]; then
             echo 'features_to_test=${{ needs.find-features.outputs.changed-features }}' >> $GITHUB_OUTPUT
-          
+
           elif [ ${{ github.event_name	}} == 'workflow_dispatch' ]; then
 
             if [ ${{ inputs.on_changes_only }} == 'true' ]; then
@@ -76,13 +76,13 @@ jobs:
             else
               echo 'features_to_test=${{ needs.find-features.outputs.all-features }}' >> $GITHUB_OUTPUT
             fi
-          
+
           elif [ ${{ github.event_name	}} == 'workflow_call' ]; then
             if [ ${{ inputs.on_changes_only }} == 'true' ]; then
               echo 'features_to_test=${{ needs.find-features.outputs.changed-features }}' >> $GITHUB_OUTPUT
             else
               echo 'features_to_test=${{ needs.find-features.outputs.all-features }}' >> $GITHUB_OUTPUT
-            fi          
+            fi
           fi
 
       - name: binning
@@ -123,7 +123,7 @@ jobs:
       matrix:
         features: ${{ fromJson(needs.prepare-matrix.outputs.features_to_test) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
@@ -140,17 +140,17 @@ jobs:
 
           # install shellcheck
           comma_separated_features=${{ matrix.features }}
-          
-          for i in ${comma_separated_features//,/ } 
+
+          for i in ${comma_separated_features//,/ }
           do
-            shellcheck --severity=error -e SC2148 src/"$i"/*.sh 
+            shellcheck --severity=error -e SC2148 src/"$i"/*.sh
           done
-        
+
   test-global:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli

--- a/src/bitwarden-cli/README.md
+++ b/src/bitwarden-cli/README.md
@@ -7,7 +7,7 @@ The Bitwarden command-line interface (CLI) is a powerful, fully-featured tool fo
 
 ```json
 "features": {
-    "ghcr.io/devcontainers-contrib/features/bitwarden-cli:1": {}
+  "ghcr.io/devcontainers-contrib/features/bitwarden-cli:1": {}
 }
 ```
 
@@ -16,5 +16,3 @@ The Bitwarden command-line interface (CLI) is a powerful, fully-featured tool fo
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | version | Select the version to install. | string | latest |
-
-

--- a/src/bitwarden-cli/devcontainer-feature.json
+++ b/src/bitwarden-cli/devcontainer-feature.json
@@ -1,20 +1,20 @@
 {
-    "id": "bitwarden-cli",
-    "version": "1.0.2",
-    "name": "Bitwarden CLI (via Github Releases)",
-    "documentationURL": "http://github.com/devcontainers-contrib/features/tree/main/src/bitwarden-cli",
-    "description": "The Bitwarden command-line interface (CLI) is a powerful, fully-featured tool for accessing and managing your vault.",
-    "options": {
-        "version": {
-            "default": "latest",
-            "description": "Select the version to install.",
-            "proposals": [
-                "latest"
-            ],
-            "type": "string"
-        }
-    },
-    "installsAfter": [
-        "ghcr.io/devcontainers-contrib/features/gh-release"
-    ]
+  "id": "bitwarden-cli",
+  "version": "1.0.2",
+  "name": "Bitwarden CLI (via Github Releases)",
+  "documentationURL": "http://github.com/devcontainers-contrib/features/tree/main/src/bitwarden-cli",
+  "description": "The Bitwarden command-line interface (CLI) is a powerful, fully-featured tool for accessing and managing your vault.",
+  "options": {
+    "version": {
+      "default": "latest",
+      "description": "Select the version to install.",
+      "proposals": [
+        "latest"
+      ],
+      "type": "string"
+    }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers-contrib/features/gh-release"
+  ]
 }

--- a/src/bitwarden-cli/install.sh
+++ b/src/bitwarden-cli/install.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 set -e
 
@@ -5,19 +6,17 @@ set -e
 
 # nanolayer is a cli utility which keeps container layers as small as possible
 # source code: https://github.com/devcontainers-contrib/nanolayer
-# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations, 
-# and if missing - will download a temporary copy that automatically get deleted at the end 
+# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations,
+# and if missing - will download a temporary copy that automatically get deleted at the end
 # of the script
-ensure_nanolayer nanolayer_location "v0.5.4"
+ensure_nanolayer nanolayer_location "v0.5.6"
 
 
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/gh-release:1.0.19" \
-    --option repo='bitwarden/clients' --option binaryNames='bw' --option releaseTagRegex='.*cli.*' --option version="$VERSION"
-    
+    "ghcr.io/devcontainers-contrib/features/gh-release:1.0.25" \
+    --option repo='bitwarden/clients' --option binaryNames='bw' --option releaseTagRegex='.*cli.*' --option assetRegex='^bw-oss.*' --option version="$VERSION"
 
 
 echo 'Done!'
-

--- a/src/bitwarden-cli/library_scripts.sh
+++ b/src/bitwarden-cli/library_scripts.sh
@@ -1,12 +1,12 @@
-
+#!/bin/sh
 
 clean_download() {
     # The purpose of this function is to download a file with minimal impact on container layer size
-    # this means if no valid downloader is found (curl or wget) then we install a downloader (currently wget) in a 
-    # temporary manner, and making sure to 
+    # this means if no valid downloader is found (curl or wget) then we install a downloader (currently wget) in a
+    # temporary manner, and making sure to
     # 1. uninstall the downloader at the return of the function
     # 2. revert back any changes to the package installer database/cache (for example apt-get lists)
-    # The above steps will minimize the leftovers being created while installing the downloader 
+    # The above steps will minimize the leftovers being created while installing the downloader
     # Supported distros:
     #  debian/ubuntu/alpine
 
@@ -18,8 +18,8 @@ clean_download() {
     _apt_get_install() {
         tempdir=$1
 
-        # copy current state of apt list - in order to revert back later (minimize contianer layer size) 
-        cp -p -R /var/lib/apt/lists $tempdir 
+        # copy current state of apt list - in order to revert back later (minimize contianer layer size)
+        cp -p -R /var/lib/apt/lists $tempdir
         apt-get update -y
         apt-get -y install --no-install-recommends wget ca-certificates
     }
@@ -37,8 +37,8 @@ clean_download() {
 
     _apk_install() {
         tempdir=$1
-        # copy current state of apk cache - in order to revert back later (minimize contianer layer size) 
-        cp -p -R /var/cache/apk $tempdir 
+        # copy current state of apk cache - in order to revert back later (minimize contianer layer size)
+        cp -p -R /var/cache/apk $tempdir
 
         apk add --no-cache  wget
     }
@@ -47,7 +47,7 @@ clean_download() {
         tempdir=$1
 
         echo "removing wget"
-        apk del wget 
+        apk del wget
     }
     # try to use either wget or curl if one of them already installer
     if type curl >/dev/null 2>&1; then
@@ -75,7 +75,7 @@ clean_download() {
     if [ $downloader = "wget" ] ; then
         wget -q $url -O $output_location
     else
-        curl -sfL $url -o $output_location 
+        curl -sfL $url -o $output_location
     fi
 
     # NOTE: the cleanup procedure was not implemented using `trap X RETURN` only because
@@ -89,7 +89,7 @@ clean_download() {
             echo "distro not supported"
             exit 1
         fi
-    fi 
+    fi
 
 }
 
@@ -128,7 +128,7 @@ ensure_nanolayer() {
 
     fi
 
-    # If not previuse installation found, download it temporarly and delete at the end of the script 
+    # If not previuse installation found, download it temporarly and delete at the end of the script
     if [ -z "${__nanolayer_location}" ]; then
 
         if [ "$(uname -sm)" = 'Linux x86_64' ] || [ "$(uname -sm)" = "Linux aarch64" ]; then
@@ -141,7 +141,7 @@ ensure_nanolayer() {
             }
             trap clean_up EXIT
 
-            
+
             if [ -x "/sbin/apk" ] ; then
                 clib_type=musl
             else
@@ -151,12 +151,12 @@ ensure_nanolayer() {
             tar_filename=nanolayer-"$(uname -m)"-unknown-linux-$clib_type.tgz
 
             # clean download will minimize leftover in case a downloaderlike wget or curl need to be installed
-            clean_download https://github.com/devcontainers-contrib/cli/releases/download/$required_version/$tar_filename $tmp_dir/$tar_filename
-            
+            clean_download https://github.com/devcontainers-contrib/nanolayer/releases/download/$required_version/$tar_filename $tmp_dir/$tar_filename
+
             tar xfzv $tmp_dir/$tar_filename -C "$tmp_dir"
             chmod a+x $tmp_dir/nanolayer
             __nanolayer_location=$tmp_dir/nanolayer
-      
+
 
         else
             echo "No binaries compiled for non-x86-linux architectures yet: $(uname -m)"

--- a/test/bitwarden-cli/scenarios.json
+++ b/test/bitwarden-cli/scenarios.json
@@ -1,8 +1,8 @@
 {
-    "test_defaults_debian": {
-        "image": "mcr.microsoft.com/devcontainers/base:debian",
-        "features": {
-            "bitwarden-cli": {}
-        }
+  "test_defaults_debian": {
+    "image": "mcr.microsoft.com/devcontainers/base:debian",
+    "features": {
+      "bitwarden-cli": {}
     }
+  }
 }


### PR DESCRIPTION
This PR fixes the bitwarden-cli feature. The issue was due to the fact bitwarden cli is now released in 2 "flavors": bw and bw-oss.

The fix downloads the "oss" version.

Additionally, the PR updates the github actions versions to avoid warning about nodejs.
