### PR TITLE
fix: respect user-defined PIPX_BIN_DIR

### DIFF
--- a/src/pipx-package/install.sh
+++ b/src/pipx-package/install.sh
@@ -86,7 +86,7 @@ install_via_pipx() {
 	export PIP_CACHE_DIR=/tmp/pip-tmp/cache
 
 	export PIPX_HOME=${PIPX_HOME:-"/usr/local/py-utils"}
-	export PIPX_BIN_DIR="${PIPX_HOME}/bin"
+	export PIPX_BIN_DIR="${PIPX_BIN_DIR:-${PIPX_HOME}/bin}"
 	mkdir -p "${PIPX_HOME}"
 
 	_install_pipx() {


### PR DESCRIPTION
If pipx is already installed in the base image, it's likely that PIPX_BIN_DIR is set to a custom location such as `/usr/local/bin`. Since this script doesn't yet support `--global`, this at least adds support for user-defined PIPX_BIN_DIRs. Without this support, the script would create broken symlinks, e.g. when installing `ghcr.io/prulloac/devcontainer-features/pre-commit:1` and `PIPX_BIN_DIR=/usr/local/bin` and `PIPX_HOME=/opt/pipx`, pipx installs the pre-commit symlink to `/opt/pipx/bin/pre-commit`, which results in a broken symlink:

```shell
root ➜ / $ which pre-commit
root ➜ / $ pipx list
venvs are in /opt/pipx/venvs
apps are exposed on your $PATH at /usr/local/bin
   package pre-commit 3.8.0, installed using Python 3.11.2
    - pre-commit (symlink missing or pointing to unexpected location)
```